### PR TITLE
Allow WordGraphArcDto.Alignment to be null

### DIFF
--- a/src/SIL.Machine.WebApi/Services/MapperProfile.cs
+++ b/src/SIL.Machine.WebApi/Services/MapperProfile.cs
@@ -78,7 +78,7 @@ public class MapperProfile : Profile
                             new WordAlignmentMatrix(
                                 dto.SourceSegmentRange.End - dto.SourceSegmentRange.Start,
                                 dto.Words.Length,
-                                dto.Alignment.Select(wp => (wp.SourceIndex, wp.TargetIndex))
+                                dto.Alignment?.Select(wp => (wp.SourceIndex, wp.TargetIndex))
                             )
                     )
             )


### PR DESCRIPTION
Sometimes when using SmtTransfer, the WordGraphArcDto.Alignment property is null, resulting in the error below.

This PR allows Alignment to be null, as the setValues parameter of WordAlignmentMatrix is nullable.

```
An unhandled exception has occurred while executing the request.
AutoMapper.AutoMapperMappingException: Error mapping types.

Mapping types:
WordGraphDto -> WordGraph
SIL.Machine.WebApi.WordGraphDto -> SIL.Machine.Translation.WordGraph

Type Map configuration:
WordGraphDto -> WordGraph
SIL.Machine.WebApi.WordGraphDto -> SIL.Machine.Translation.WordGraph

Destination Member:
SIL.Machine.Translation.WordGraph.Void .ctor(System.Collections.Generic.IEnumerable`1[SIL.Machine.Translation.WordGraphArc], System.Collections.Generic.IEnumerable`1[System.Int32], Double).parameter arcs

---> AutoMapper.AutoMapperMappingException: Error mapping types.

Mapping types:
WordGraphArcDto -> WordGraphArc
SIL.Machine.WebApi.WordGraphArcDto -> SIL.Machine.Translation.WordGraphArc

Type Map configuration:
WordGraphArcDto -> WordGraphArc
SIL.Machine.WebApi.WordGraphArcDto -> SIL.Machine.Translation.WordGraphArc

Destination Member:
SIL.Machine.Translation.WordGraphArc.Void .ctor(Int32, Int32, Double, System.Collections.Generic.IEnumerable`1[System.String], SIL.Machine.Translation.WordAlignmentMatrix, SIL.Machine.Annotations.Range`1[System.Int32], System.Collections.Generic.IEnumerable`1[SIL.Machine.Translation.TranslationSources], System.Collections.Generic.IEnumerable`1[System.Double]).parameter alignment
```