### PR TITLE
Fixes ClearML server is down - and then hangfire crashes #65 --ECL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+.history*
 
 *.Resharper
 *.DotSettings

--- a/src/SIL.Machine.AspNetCore/Configuration/IMachineBuilderExtensions.cs
+++ b/src/SIL.Machine.AspNetCore/Configuration/IMachineBuilderExtensions.cs
@@ -107,6 +107,12 @@ public static class IMachineBuilderExtensions
         builder.Services.AddSingleton<IClearMLAuthenticationService, ClearMLAuthenticationService>();
         builder.Services.AddHostedService(p => p.GetRequiredService<IClearMLAuthenticationService>());
 
+        builder.Services
+            .AddHttpClient<IClearMLAuthenticationService, ClearMLAuthenticationService>()
+            .AddTransientHttpErrorPolicy(
+                b => b.WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+            );
+
         return builder;
     }
 

--- a/src/SIL.Machine.AspNetCore/SIL.Machine.AspNetCore.csproj
+++ b/src/SIL.Machine.AspNetCore/SIL.Machine.AspNetCore.csproj
@@ -33,6 +33,7 @@
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="Hangfire.Mongo" Version="1.9.3" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.16" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.14" />
 		<PackageReference Include="Serval.Grpc" Version="0.8.0" Condition="!Exists('..\..\..\serval\src\Serval.Grpc\Serval.Grpc.csproj')" />
 		<PackageReference Include="SIL.DataAccess" Version="0.4.0" Condition="!Exists('..\..\..\serval\src\SIL.DataAccess\SIL.DataAccess.csproj')" />
 		<PackageReference Include="SIL.WritingSystems" Version="12.0.1" />

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLHealthCheck.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLHealthCheck.cs
@@ -1,12 +1,10 @@
 public class ClearMLHealthCheck : IHealthCheck
 {
     private readonly IClearMLService _clearMLService;
-    private readonly ILogger _logger;
 
-    public ClearMLHealthCheck(IClearMLService clearMLService, ILoggerFactory loggerFactory)
+    public ClearMLHealthCheck(IClearMLService clearMLService)
     {
         _clearMLService = clearMLService;
-        _logger = loggerFactory.CreateLogger<S3HealthCheck>();
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(
@@ -26,12 +24,7 @@ public class ClearMLHealthCheck : IHealthCheck
         }
         catch (Exception e)
         {
-            _logger.LogError(
-                "ClearML is not available. The following exception occurred while pinging ClearML " + e.Message
-            );
-            return HealthCheckResult.Unhealthy(
-                "ClearML is not available. The following exception occurred while pinging ClearML " + e.Message
-            );
+            return HealthCheckResult.Unhealthy(exception: e);
         }
     }
 }

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
@@ -244,7 +244,7 @@ public class ClearMLService : IClearMLService
         {
             Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json")
         };
-        request.Headers.Add("Authorization", $"Bearer {_clearMLAuthService.GetAuthToken()}");
+        request.Headers.Add("Authorization", $"Bearer {await _clearMLAuthService.GetAuthTokenAsync()}");
         HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
         string result = await response.Content.ReadAsStringAsync(cancellationToken);
         return (JsonObject?)JsonNode.Parse(result);

--- a/src/SIL.Machine.AspNetCore/Services/IClearMLAuthenticationService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/IClearMLAuthenticationService.cs
@@ -2,5 +2,5 @@
 
 public interface IClearMLAuthenticationService : IHostedService
 {
-    public string GetAuthToken();
+    public Task<string> GetAuthTokenAsync(CancellationToken cancellationToken = default);
 }

--- a/src/SIL.Machine.AspNetCore/Usings.cs
+++ b/src/SIL.Machine.AspNetCore/Usings.cs
@@ -31,6 +31,7 @@ global using Microsoft.Extensions.Options;
 global using MongoDB.Driver;
 global using MongoDB.Driver.Linq;
 global using Nito.AsyncEx;
+global using Polly;
 global using SIL.DataAccess;
 global using SIL.Machine.AspNetCore.Configuration;
 global using SIL.Machine.AspNetCore.Models;

--- a/src/SIL.Machine.Serval.EngineServer/appsettings.Development.json
+++ b/src/SIL.Machine.Serval.EngineServer/appsettings.Development.json
@@ -15,7 +15,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient.Default": "Warning"
     }
   }
 }

--- a/src/SIL.Machine.Serval.EngineServer/appsettings.json
+++ b/src/SIL.Machine.Serval.EngineServer/appsettings.json
@@ -5,5 +5,10 @@
   },
   "SmtTransferEngine": {
     "EnginesDir": "/var/lib/machine/engines"
+  },
+  "Logging": {
+    "LogLevel": {
+      "System.Net.Http.HttpClient.Default": "Warning"
+    }
   }
 }

--- a/tests/SIL.Machine.AspNetCore.Tests/Services/ClearMLServiceTests.cs
+++ b/tests/SIL.Machine.AspNetCore.Tests/Services/ClearMLServiceTests.cs
@@ -28,7 +28,7 @@ public class ClearMLServiceTests
             }
         );
         var authService = Substitute.For<IClearMLAuthenticationService>();
-        authService.GetAuthToken().Returns("accessToken");
+        authService.GetAuthTokenAsync().Returns(Task.FromResult("accessToken"));
         var service = new ClearMLService(
             mockHttp.ToHttpClient(),
             options,


### PR DESCRIPTION
Also relevant to #50. 

* Used Polly to auto-retry
* Refactored `ClearMLAuthenticationService` a bit to avoid issue where token wasn't properly populating immediately
* Small fixes in the `ClearMLHealthCheck` and to logging
* (Added ".history" to the gitignore - vs code extension generates files in this folder on my box and, I presume, others)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/66)
<!-- Reviewable:end -->
