### PR TITLE
Removed cancellation token passing after line 99.

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/SmtTransferEngineBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/SmtTransferEngineBuildJob.cs
@@ -97,13 +97,12 @@ public class SmtTransferEngineBuildJob
             await using (await rwLock.WriterLockAsync(cancellationToken: cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await smtModelTrainer.SaveAsync(cancellationToken);
-                await truecaseTrainer.SaveAsync(cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
+                await smtModelTrainer.SaveAsync(CancellationToken.None);
+                await truecaseTrainer.SaveAsync(CancellationToken.None);
                 ITruecaser truecaser = await _truecaserFactory.CreateAsync(engineId);
                 IReadOnlyList<TrainSegmentPair> segmentPairs = await _trainSegmentPairs.GetAllAsync(
                     p => p.TranslationEngineRef == engine!.Id,
-                    cancellationToken
+                    CancellationToken.None
                 );
                 using (
                     IInteractiveTranslationModel smtModel = _smtModelFactory.Create(
@@ -119,9 +118,8 @@ public class SmtTransferEngineBuildJob
                         await smtModel.TrainSegmentAsync(
                             segmentPair.Source,
                             segmentPair.Target,
-                            cancellationToken: cancellationToken
+                            cancellationToken: CancellationToken.None
                         );
-                        cancellationToken.ThrowIfCancellationRequested();
                     }
                 }
 


### PR DESCRIPTION
Opted to explicitly pass CancellationToken.None rather than leaving default for consistency with other code and added clarity.

Fixes Cancellation token - inconsistent SMT training state #62

--ECL

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/71)
<!-- Reviewable:end -->
