### PR TITLE
Fixes S3 bucket unecessary alerts

### DIFF
--- a/src/SIL.Machine.AspNetCore/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SIL.Machine.AspNetCore/Configuration/IServiceCollectionExtensions.cs
@@ -5,10 +5,7 @@ public static class IServiceCollectionExtensions
     public static IMachineBuilder AddMachine(this IServiceCollection services, IConfiguration? configuration = null)
     {
         services.AddSingleton<ISharedFileService, SharedFileService>();
-        services.Configure<HealthCheckPublisherOptions>(options =>
-        {
-            options.Period = TimeSpan.FromSeconds(240);
-        });
+        services.AddSingleton<S3HealthCheck>();
         services.AddHealthChecks().AddCheck<S3HealthCheck>("S3 Bucket");
         services.AddScoped<IDistributedReaderWriterLockFactory, DistributedReaderWriterLockFactory>();
         services.AddSingleton<ICorpusService, CorpusService>();

--- a/src/SIL.Machine.AspNetCore/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SIL.Machine.AspNetCore/Configuration/IServiceCollectionExtensions.cs
@@ -5,6 +5,10 @@ public static class IServiceCollectionExtensions
     public static IMachineBuilder AddMachine(this IServiceCollection services, IConfiguration? configuration = null)
     {
         services.AddSingleton<ISharedFileService, SharedFileService>();
+        services.Configure<HealthCheckPublisherOptions>(options =>
+        {
+            options.Period = TimeSpan.FromSeconds(240);
+        });
         services.AddHealthChecks().AddCheck<S3HealthCheck>("S3 Bucket");
         services.AddScoped<IDistributedReaderWriterLockFactory, DistributedReaderWriterLockFactory>();
         services.AddSingleton<ICorpusService, CorpusService>();

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLHealthCheck.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLHealthCheck.cs
@@ -1,10 +1,16 @@
 public class ClearMLHealthCheck : IHealthCheck
 {
-    private readonly ClearMLService _clearMLService;
+    private readonly HttpClient _httpClient;
+    private readonly IOptionsMonitor<ClearMLNmtEngineOptions> _options;
+    private string _authToken;
+    private readonly AsyncLock _lock;
 
-    public ClearMLHealthCheck(ClearMLService clearMLService)
+    public ClearMLHealthCheck(HttpClient httpClient, IOptionsMonitor<ClearMLNmtEngineOptions> options)
     {
-        _clearMLService = clearMLService;
+        _httpClient = httpClient;
+        _options = options;
+        _authToken = "";
+        _lock = new AsyncLock();
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(
@@ -14,11 +20,12 @@ public class ClearMLHealthCheck : IHealthCheck
     {
         try
         {
-            bool success = await _clearMLService.PingAsync();
-            if (!success)
+            using (await _lock.LockAsync())
+                if (_authToken == "")
+                    _authToken = await GetAuthTokenAsync(cancellationToken);
+            if (!await PingAsync(cancellationToken))
                 return HealthCheckResult.Unhealthy("ClearML is unresponsive");
-            bool workersAvailable = await _clearMLService.WorkersAreAssignedToQueue();
-            if (!workersAvailable)
+            if (!await WorkersAreAssignedToQueue(cancellationToken))
                 return HealthCheckResult.Unhealthy("No ClearML agents are available");
             return HealthCheckResult.Healthy("ClearML is available");
         }
@@ -26,5 +33,64 @@ public class ClearMLHealthCheck : IHealthCheck
         {
             return HealthCheckResult.Unhealthy(exception: e);
         }
+    }
+
+    private async Task<string> GetAuthTokenAsync(CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{_options.CurrentValue.ApiServer}/auth.login")
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var authenticationString = $"{_options.CurrentValue.AccessKey}:{_options.CurrentValue.SecretKey}";
+        var base64EncodedAuthenticationString = Convert.ToBase64String(Encoding.ASCII.GetBytes(authenticationString));
+        request.Headers.Add("Authorization", $"Basic {base64EncodedAuthenticationString}");
+        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        string result = await response.Content.ReadAsStringAsync(cancellationToken);
+        return (string)((JsonObject?)JsonNode.Parse(result))?["data"]?["token"]!;
+    }
+
+    private async Task<JsonObject?> CallAsync(
+        string service,
+        string action,
+        JsonNode body,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{_options.CurrentValue.ApiServer}/{service}.{action}")
+        {
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json")
+        };
+        request.Headers.Add("Authorization", $"Bearer {_authToken}");
+        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        string result = await response.Content.ReadAsStringAsync(cancellationToken);
+        return (JsonObject?)JsonNode.Parse(result);
+    }
+
+    public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
+    {
+        JsonObject? result = await CallAsync("debug", "ping", new JsonObject(), cancellationToken);
+        return result is not null;
+    }
+
+    public async Task<bool> WorkersAreAssignedToQueue(CancellationToken cancellationToken = default)
+    {
+        JsonObject? result = await CallAsync("workers", "get_all", new JsonObject(), cancellationToken);
+        JsonNode? workers_node = result?["data"]?["workers"];
+        if (workers_node is null)
+            return false;
+        JsonArray workers = (JsonArray)workers_node;
+        foreach (var worker in workers)
+        {
+            JsonNode? queues_node = worker?["queues"];
+            if (queues_node is null)
+                continue;
+            JsonArray queues = (JsonArray)queues_node;
+            foreach (var queue in queues)
+            {
+                if ((string?)queue?["name"] == _options.CurrentValue.Queue)
+                    return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLHealthCheck.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLHealthCheck.cs
@@ -1,8 +1,8 @@
 public class ClearMLHealthCheck : IHealthCheck
 {
-    private readonly IClearMLService _clearMLService;
+    private readonly ClearMLService _clearMLService;
 
-    public ClearMLHealthCheck(IClearMLService clearMLService)
+    public ClearMLHealthCheck(ClearMLService clearMLService)
     {
         _clearMLService = clearMLService;
     }

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
@@ -188,34 +188,6 @@ public class ClearMLService : IClearMLService
         return results;
     }
 
-    public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
-    {
-        JsonObject? result = await CallAsync("debug", "ping", new JsonObject(), cancellationToken);
-        return result is not null;
-    }
-
-    public async Task<bool> WorkersAreAssignedToQueue(CancellationToken cancellationToken = default)
-    {
-        JsonObject? result = await CallAsync("workers", "get_all", new JsonObject(), cancellationToken);
-        JsonNode? workers_node = result?["data"]?["workers"];
-        if (workers_node is null)
-            return false;
-        JsonArray workers = (JsonArray)workers_node;
-        foreach (var worker in workers)
-        {
-            JsonNode? queues_node = worker?["queues"];
-            if (queues_node is null)
-                continue;
-            JsonArray queues = (JsonArray)queues_node;
-            foreach (var queue in queues)
-            {
-                if ((string?)queue?["name"] == _options.CurrentValue.Queue)
-                    return true;
-            }
-        }
-        return false;
-    }
-
     private async Task<ClearMLTask?> GetTaskAsync(JsonObject body, CancellationToken cancellationToken = default)
     {
         body["only_fields"] = new JsonArray(

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
@@ -26,7 +26,8 @@ public class ClearMLService : IClearMLService
         _options = options;
         _logger = logger;
         _clearMLAuthService = clearMLAuthService;
-        Sldr.Initialize();
+        if (!Sldr.IsInitialized)
+            Sldr.Initialize();
     }
 
     public async Task<string?> GetProjectIdAsync(string name, CancellationToken cancellationToken = default)

--- a/src/SIL.Machine.AspNetCore/Services/IClearMLService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/IClearMLService.cs
@@ -28,8 +28,4 @@ public interface IClearMLService
         string id,
         CancellationToken cancellationToken = default
     );
-
-    Task<bool> PingAsync(CancellationToken cancellationToken = default);
-
-    Task<bool> WorkersAreAssignedToQueue(CancellationToken cancellationToken = default);
 }

--- a/src/SIL.Machine.AspNetCore/Services/S3FileStorage.cs
+++ b/src/SIL.Machine.AspNetCore/Services/S3FileStorage.cs
@@ -19,12 +19,7 @@ public class S3FileStorage : FileStorage
         _client = new AmazonS3Client(
             accessKeyId,
             secretAccessKey,
-            new AmazonS3Config
-            {
-                RetryMode = RequestRetryMode.Standard,
-                MaxErrorRetry = 3,
-                RegionEndpoint = RegionEndpoint.GetBySystemName(region)
-            }
+            new AmazonS3Config { RegionEndpoint = RegionEndpoint.GetBySystemName(region) }
         );
 
         _bucketName = bucketName;

--- a/src/SIL.Machine.AspNetCore/Services/S3HealthCheck.cs
+++ b/src/SIL.Machine.AspNetCore/Services/S3HealthCheck.cs
@@ -20,7 +20,6 @@ public class S3HealthCheck : IHealthCheck
     {
         try
         {
-            _logger.LogInformation($"{DateTime.Now}");
             await _sharedFileService.Ls("/models/");
             return HealthCheckResult.Healthy("The S3 bucket is available");
         }


### PR DESCRIPTION
Change interval of health checks to 4 minutes.

S3 pings up to three times before returning Unhealthy.

(Also, removed redundant logging)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/85)
<!-- Reviewable:end -->
