### PR TITLE
Required features on allomorphs should use subsumption

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AffixProcessAllomorph.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AffixProcessAllomorph.cs
@@ -86,7 +86,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 			if (!base.IsWordValid(morpher, word))
 				return false;
 
-			if (!RequiredSyntacticFeatureStruct.IsUnifiable(word.SyntacticFeatureStruct))
+			if (!RequiredSyntacticFeatureStruct.Subsumes(word.SyntacticFeatureStruct))
 			{
 				if (morpher.TraceManager.IsTracing)
 					morpher.TraceManager.Failed(morpher.Language, word, FailureReason.RequiredSyntacticFeatureStruct, this, RequiredSyntacticFeatureStruct);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/87)
<!-- Reviewable:end -->
