### PR TITLE
Fixes RefId's don't get populated for Paratext Projects #93

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/ClearMLNmtEngineBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLNmtEngineBuildJob.cs
@@ -291,7 +291,9 @@ public class ClearMLNmtEngineBuildJob
                         {
                             CorpusId = corpus.Id,
                             TextId = row.TextId,
-                            Refs = row.TargetRefs.Select(r => r.ToString()!).ToList(),
+                            Refs = row.TargetRefs.Any()
+                                ? row.TargetRefs.Select(r => r.ToString()!).ToList()
+                                : row.SourceRefs.Select(r => r.ToString()!).ToList(),
                             Translation = row.SourceText
                         };
                     }

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLNmtEngineBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLNmtEngineBuildJob.cs
@@ -287,13 +287,35 @@ public class ClearMLNmtEngineBuildJob
                         && row.TargetSegment.Count == 0
                     )
                     {
+                        IReadOnlyList<object> refs;
+                        if (row.TargetRefs.Count == 0)
+                        {
+                            if (sourceCorpus is ScriptureTextCorpus sstc && targetCorpus is ScriptureTextCorpus tstc)
+                            {
+                                refs = row.SourceRefs
+                                    .Cast<VerseRef>()
+                                    .Select(srcRef =>
+                                    {
+                                        var trgRef = srcRef.Clone();
+                                        trgRef.ChangeVersification(tstc.Versification);
+                                        return (object)trgRef;
+                                    })
+                                    .ToList();
+                            }
+                            else
+                            {
+                                refs = row.SourceRefs;
+                            }
+                        }
+                        else
+                        {
+                            refs = row.TargetRefs;
+                        }
                         yield return new Pretranslation
                         {
                             CorpusId = corpus.Id,
                             TextId = row.TextId,
-                            Refs = row.TargetRefs.Any()
-                                ? row.TargetRefs.Select(r => r.ToString()!).ToList()
-                                : row.SourceRefs.Select(r => r.ToString()!).ToList(),
+                            Refs = refs.Select(r => r.ToString()!).ToList(),
                             Translation = row.SourceText
                         };
                     }

--- a/src/SIL.Machine.AspNetCore/Usings.cs
+++ b/src/SIL.Machine.AspNetCore/Usings.cs
@@ -46,3 +46,4 @@ global using SIL.Machine.Translation.Thot;
 global using SIL.Machine.Utils;
 global using SIL.ObjectModel;
 global using SIL.WritingSystems;
+global using SIL.Scripture;


### PR DESCRIPTION
If there is no target file, there are no target refs; in this case, use the source ref.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/94)
<!-- Reviewable:end -->
