### PR TITLE
Fix corpus count methods

### DIFF
--- a/src/SIL.Machine.Serval.EngineServer/appsettings.Development.json
+++ b/src/SIL.Machine.Serval.EngineServer/appsettings.Development.json
@@ -7,7 +7,8 @@
   "ClearML": {
     "Queue": "jobs_backlog",
     "MaxSteps": 1000,
-    "Project": "dev"
+    "Project": "dev",
+    "DockerImage": "ghcr.io/sillsdev/machine.py:latest"
   },
   "SharedFile": {
     "Uri": "s3://aqua-ml-data/dev/"

--- a/src/SIL.Machine.Serval.JobServer/appsettings.Development.json
+++ b/src/SIL.Machine.Serval.JobServer/appsettings.Development.json
@@ -7,7 +7,8 @@
   "ClearML": {
     "Queue": "jobs_backlog",
     "MaxSteps": 1000,
-    "Project": "dev"
+    "Project": "dev",
+    "DockerImage": "ghcr.io/sillsdev/machine.py:latest"
   },
   "SharedFile": {
     "Uri": "s3://aqua-ml-data/dev/"

--- a/src/SIL.Machine/Corpora/CorporaExtensions.cs
+++ b/src/SIL.Machine/Corpora/CorporaExtensions.cs
@@ -365,8 +365,6 @@ namespace SIL.Machine.Corpora
 
             public override IEnumerable<IText> Texts => _corpus.Texts;
 
-            public override bool MissingRowsAllowed => _corpus.MissingRowsAllowed;
-
             public override bool IsTokenized { get; }
 
             public override int Count(bool includeEmpty = true)
@@ -456,8 +454,6 @@ namespace SIL.Machine.Corpora
 
             public override bool IsTokenized => _corpora.All(corpus => corpus.IsTokenized);
 
-            public override bool MissingRowsAllowed => _corpora.Any(corpus => corpus.MissingRowsAllowed);
-
             public override int Count(bool includeEmpty = true)
             {
                 return _corpora.Sum(corpus => corpus.Count(includeEmpty));
@@ -531,8 +527,6 @@ namespace SIL.Machine.Corpora
             }
 
             public override IEnumerable<IAlignmentCollection> AlignmentCollections => _corpus.AlignmentCollections;
-
-            public override bool MissingRowsAllowed => _corpus.MissingRowsAllowed;
 
             public override int Count(bool includeEmpty = true)
             {
@@ -617,8 +611,6 @@ namespace SIL.Machine.Corpora
 
             public override IEnumerable<IAlignmentCollection> AlignmentCollections =>
                 _corpora.SelectMany(corpus => corpus.AlignmentCollections);
-
-            public override bool MissingRowsAllowed => _corpora.Any(corpus => corpus.MissingRowsAllowed);
 
             public override int Count(bool includeEmpty = true)
             {
@@ -1046,8 +1038,6 @@ namespace SIL.Machine.Corpora
                 IsTargetTokenized = isTargetTokenized ?? corpus.IsTargetTokenized;
             }
 
-            public override bool MissingRowsAllowed => _corpus.MissingRowsAllowed;
-
             public override bool IsSourceTokenized { get; }
 
             public override bool IsTargetTokenized { get; }
@@ -1111,8 +1101,6 @@ namespace SIL.Machine.Corpora
             {
                 _corpora = corpora;
             }
-
-            public override bool MissingRowsAllowed => _corpora.Any(corpus => corpus.MissingRowsAllowed);
 
             public override bool IsSourceTokenized => _corpora.All(corpus => corpus.IsSourceTokenized);
             public override bool IsTargetTokenized => _corpora.All(corpus => corpus.IsTargetTokenized);

--- a/src/SIL.Machine/Corpora/CorpusBase.cs
+++ b/src/SIL.Machine/Corpora/CorpusBase.cs
@@ -7,8 +7,6 @@ namespace SIL.Machine.Corpora
     public abstract class CorpusBase<T> : ICorpus<T>
         where T : IRow
     {
-        public virtual bool MissingRowsAllowed => true;
-
         public virtual int Count(bool includeEmpty = true)
         {
             return includeEmpty ? GetRows().Count() : GetRows().Count(r => !r.IsEmpty);

--- a/src/SIL.Machine/Corpora/DictionaryAlignmentCorpus.cs
+++ b/src/SIL.Machine/Corpora/DictionaryAlignmentCorpus.cs
@@ -19,8 +19,6 @@ namespace SIL.Machine.Corpora
         public override IEnumerable<IAlignmentCollection> AlignmentCollections =>
             _alignmentCollections.Values.OrderBy(ac => ac.SortKey);
 
-        public override bool MissingRowsAllowed => AlignmentCollections.Any(t => t.MissingRowsAllowed);
-
         public override int Count(bool includeEmpty = true)
         {
             return AlignmentCollections.Sum(t => t.Count(includeEmpty));

--- a/src/SIL.Machine/Corpora/DictionaryTextCorpus.cs
+++ b/src/SIL.Machine/Corpora/DictionaryTextCorpus.cs
@@ -19,8 +19,6 @@ namespace SIL.Machine.Corpora
 
         public IText this[string id] => TextDictionary[id];
 
-        public override bool MissingRowsAllowed => Texts.Any(t => t.MissingRowsAllowed);
-
         public bool IsTokenized { get; set; }
 
         public override int Count(bool includeEmpty = true)

--- a/src/SIL.Machine/Corpora/ICorpus.cs
+++ b/src/SIL.Machine/Corpora/ICorpus.cs
@@ -5,8 +5,6 @@ namespace SIL.Machine.Corpora
     public interface ICorpus<T> : IEnumerable<T>
         where T : IRow
     {
-        bool MissingRowsAllowed { get; }
-
         int Count(bool includeEmpty = true);
 
         IEnumerable<T> GetRows();

--- a/src/SIL.Machine/Corpora/MemoryAlignmentCollection.cs
+++ b/src/SIL.Machine/Corpora/MemoryAlignmentCollection.cs
@@ -21,8 +21,6 @@ namespace SIL.Machine.Corpora
 
         public string SortKey => Id;
 
-        public bool MissingRowsAllowed => true;
-
         public int Count(bool includeEmpty = true)
         {
             return includeEmpty ? _rows.Length : GetRows().Count(r => !r.IsEmpty);

--- a/src/SIL.Machine/Corpora/MemoryText.cs
+++ b/src/SIL.Machine/Corpora/MemoryText.cs
@@ -20,8 +20,6 @@ namespace SIL.Machine.Corpora
         public string Id { get; }
         public string SortKey => Id;
 
-        public bool MissingRowsAllowed => true;
-
         public int Count(bool includeEmpty = true)
         {
             return includeEmpty ? _rows.Length : GetRows().Count(r => !r.IsEmpty);

--- a/src/SIL.Machine/Corpora/ParallelTextCorpus.cs
+++ b/src/SIL.Machine/Corpora/ParallelTextCorpus.cs
@@ -33,26 +33,9 @@ namespace SIL.Machine.Corpora
         public IAlignmentCorpus AlignmentCorpus { get; }
         public IComparer<object> RowRefComparer { get; }
 
-        public bool MissingRowsAllowed
-        {
-            get
-            {
-                if (SourceCorpus.MissingRowsAllowed || TargetCorpus.MissingRowsAllowed)
-                    return true;
-
-                var sourceTextIds = new HashSet<string>(SourceCorpus.Texts.Select(t => t.Id));
-                var targetTextIds = new HashSet<string>(TargetCorpus.Texts.Select(t => t.Id));
-                return !sourceTextIds.SetEquals(targetTextIds);
-            }
-        }
-
         public int Count(bool includeEmpty = true)
         {
-            if (MissingRowsAllowed)
-                return includeEmpty ? GetRows().Count() : GetRows().Count(r => !r.IsEmpty);
-            if (includeEmpty)
-                return SourceCorpus.Count(includeEmpty);
-            return Math.Min(SourceCorpus.Count(includeEmpty), TargetCorpus.Count(includeEmpty));
+            return includeEmpty ? GetRows().Count() : GetRows().Count(r => !r.IsEmpty);
         }
 
         public IEnumerator<ParallelTextRow> GetEnumerator()

--- a/src/SIL.Machine/Corpora/TextBase.cs
+++ b/src/SIL.Machine/Corpora/TextBase.cs
@@ -17,8 +17,6 @@ namespace SIL.Machine.Corpora
 
         public string SortKey { get; }
 
-        public virtual bool MissingRowsAllowed => true;
-
         public virtual int Count(bool includeEmpty = true)
         {
             return includeEmpty ? GetRows().Count() : GetRows().Count(r => !r.IsEmpty);

--- a/src/SIL.Machine/Corpora/TextFileAlignmentCollection.cs
+++ b/src/SIL.Machine/Corpora/TextFileAlignmentCollection.cs
@@ -19,8 +19,6 @@ namespace SIL.Machine.Corpora
 
         public string SortKey => Id;
 
-        public bool MissingRowsAllowed => false;
-
         public int Count(bool includeEmpty = true)
         {
             using (var reader = new StreamReader(_fileName))
@@ -29,8 +27,18 @@ namespace SIL.Machine.Corpora
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    if (includeEmpty || line.Trim().Length > 0)
+                    if (includeEmpty)
+                    {
                         count++;
+                    }
+                    else if (line.Length > 0)
+                    {
+                        int index = line.IndexOf("\t");
+                        if (index >= 0)
+                            line = line.Substring(index + 1);
+                        if (line.Trim().Length > 0)
+                            count++;
+                    }
                 }
                 return count;
             }

--- a/src/SIL.Machine/Corpora/TextFileText.cs
+++ b/src/SIL.Machine/Corpora/TextFileText.cs
@@ -15,8 +15,6 @@ namespace SIL.Machine.Corpora
 
         public string FileName { get; }
 
-        public override bool MissingRowsAllowed => false;
-
         public override int Count(bool includeEmpty = true)
         {
             using (var reader = new StreamReader(FileName))
@@ -25,8 +23,18 @@ namespace SIL.Machine.Corpora
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    if (includeEmpty || line.Trim().Length > 0)
+                    if (includeEmpty)
+                    {
                         count++;
+                    }
+                    else if (line.Length > 0)
+                    {
+                        string[] columns = line.Split('\t');
+                        if (columns.Length > 1)
+                            line = columns[1];
+                        if (line.Trim().Length > 0)
+                            count++;
+                    }
                 }
                 return count;
             }

--- a/src/SIL.Machine/Corpora/UsxFileAlignmentCollection.cs
+++ b/src/SIL.Machine/Corpora/UsxFileAlignmentCollection.cs
@@ -49,8 +49,6 @@ namespace SIL.Machine.Corpora
 
         public string SortKey { get; }
 
-        public bool MissingRowsAllowed => true;
-
         public int Count(bool includeEmpty = true)
         {
             return includeEmpty ? GetRows().Count() : GetRows().Count(r => !r.IsEmpty);

--- a/tests/SIL.Machine.Tests/Corpora/ParallelTextCorpusTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParallelTextCorpusTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SIL.Scripture;
 
 namespace SIL.Machine.Corpora
@@ -996,6 +992,81 @@ namespace SIL.Machine.Corpora
                 rows[3].TargetSegment,
                 Is.EqualTo("target chapter one, verse four . target chapter one, verse five .".Split())
             );
+        }
+
+        [Test]
+        public void Count_NoRows()
+        {
+            var sourceCorpus = new DictionaryTextCorpus();
+            var targetCorpus = new DictionaryTextCorpus();
+            var parallelCorpus = new ParallelTextCorpus(sourceCorpus, targetCorpus);
+
+            Assert.That(parallelCorpus.Count(includeEmpty: true), Is.EqualTo(0));
+            Assert.That(parallelCorpus.Count(includeEmpty: false), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Count_MissingRow()
+        {
+            var sourceCorpus = new DictionaryTextCorpus(
+                new MemoryText(
+                    "text1",
+                    new[] { TextRow("text1", 1, "source segment 1 ."), TextRow("text1", 2, "source segment 2 .") }
+                )
+            );
+            var targetCorpus = new DictionaryTextCorpus(
+                new MemoryText(
+                    "text1",
+                    new[]
+                    {
+                        TextRow("text1", 1, "target segment 1 ."),
+                        TextRow("text1", 2, "target segment 2 ."),
+                        TextRow("text1", 3, "target segment 3 .")
+                    }
+                )
+            );
+
+            var parallelCorpus = new ParallelTextCorpus(sourceCorpus, targetCorpus);
+
+            Assert.That(parallelCorpus.Count(includeEmpty: true), Is.EqualTo(2));
+            Assert.That(parallelCorpus.Count(includeEmpty: false), Is.EqualTo(2));
+
+            parallelCorpus = new ParallelTextCorpus(sourceCorpus, targetCorpus) { AllTargetRows = true };
+
+            Assert.That(parallelCorpus.Count(includeEmpty: true), Is.EqualTo(3));
+            Assert.That(parallelCorpus.Count(includeEmpty: false), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Count_EmptyRow()
+        {
+            var sourceCorpus = new DictionaryTextCorpus(
+                new MemoryText(
+                    "text1",
+                    new[]
+                    {
+                        TextRow("text1", 1, "source segment 1 ."),
+                        TextRow("text1", 2, "source segment 2 ."),
+                        TextRow("text1", 3, "source segment 3 .")
+                    }
+                )
+            );
+            var targetCorpus = new DictionaryTextCorpus(
+                new MemoryText(
+                    "text1",
+                    new[]
+                    {
+                        TextRow("text1", 1, "target segment 1 ."),
+                        TextRow("text1", 2),
+                        TextRow("text1", 3, "target segment 3 .")
+                    }
+                )
+            );
+
+            var parallelCorpus = new ParallelTextCorpus(sourceCorpus, targetCorpus);
+
+            Assert.That(parallelCorpus.Count(includeEmpty: true), Is.EqualTo(3));
+            Assert.That(parallelCorpus.Count(includeEmpty: false), Is.EqualTo(2));
         }
 
         private static TextRow TextRow(

--- a/tests/SIL.Machine.Tests/Corpora/TestData/txt/Test3.txt
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/txt/Test3.txt
@@ -1,3 +1,4 @@
 Line one.
 Line two.
 Line three.
+

--- a/tests/SIL.Machine.Tests/Corpora/TextFileTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/TextFileTextTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace SIL.Machine.Corpora
 {
@@ -44,7 +43,7 @@ namespace SIL.Machine.Corpora
             var corpus = new TextFileTextCorpus(CorporaTestHelpers.TextTestProjectPath);
             IText text = corpus["Test3"];
             TextRow[] rows = text.GetRows().ToArray();
-            Assert.That(rows.Length, Is.EqualTo(3));
+            Assert.That(rows.Length, Is.EqualTo(4));
 
             Assert.That(rows[0].Ref, Is.EqualTo(new MultiKeyRef("Test3", 1)));
             Assert.That(rows[0].Text, Is.EqualTo("Line one."));
@@ -63,6 +62,36 @@ namespace SIL.Machine.Corpora
             IText text = corpus["Test2"];
             TextRow[] rows = text.GetRows().ToArray();
             Assert.That(rows, Is.Empty);
+        }
+
+        [Test]
+        public void Count_NonEmptyText_Refs()
+        {
+            var corpus = new TextFileTextCorpus(CorporaTestHelpers.TextTestProjectPath);
+            IText text = corpus["Test1"];
+
+            Assert.That(text.Count(includeEmpty: true), Is.EqualTo(5));
+            Assert.That(text.Count(includeEmpty: false), Is.EqualTo(4));
+        }
+
+        [Test]
+        public void Count_NonEmptyText_NoRefs()
+        {
+            var corpus = new TextFileTextCorpus(CorporaTestHelpers.TextTestProjectPath);
+            IText text = corpus["Test3"];
+
+            Assert.That(text.Count(includeEmpty: true), Is.EqualTo(4));
+            Assert.That(text.Count(includeEmpty: false), Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Count_EmptyText()
+        {
+            var corpus = new TextFileTextCorpus(CorporaTestHelpers.TextTestProjectPath);
+            IText text = corpus["Test2"];
+
+            Assert.That(text.Count(includeEmpty: true), Is.EqualTo(0));
+            Assert.That(text.Count(includeEmpty: false), Is.EqualTo(0));
         }
     }
 }


### PR DESCRIPTION
- add support multiple columns in TextFileText.Count method
- remove MissingRowsAllowed property
- use standard Count implementation for ParallelTextCorpus