### PR TITLE
Fixes #118

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/ClearMLMonitorService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLMonitorService.cs
@@ -1,4 +1,6 @@
-﻿namespace SIL.Machine.AspNetCore.Services;
+﻿using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
+
+namespace SIL.Machine.AspNetCore.Services;
 
 public class ClearMLMonitorService : RecurrentTask
 {
@@ -53,7 +55,9 @@ public class ClearMLMonitorService : RecurrentTask
                     trainingEngines.Select(e => e.CurrentBuild!.JobId),
                     cancellationToken
                 )
-            ).ToDictionary(t => t.Id);
+            )
+                .UnionBy(await _clearMLService.GetTasksForCurrentQueueAsync(cancellationToken), t => t.Id)
+                .ToDictionary(t => t.Id);
 
             Dictionary<string, int> queuePositions = tasks.Values
                 .Where(t => t.Status is ClearMLTaskStatus.Queued or ClearMLTaskStatus.Created)

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLService.cs
@@ -145,6 +145,17 @@ public class ClearMLService : IClearMLService
         return updated == 1;
     }
 
+    public async Task<IReadOnlyList<ClearMLTask>> GetTasksForCurrentQueueAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        var body = new JsonObject { ["name"] = _options.CurrentValue.Queue };
+        JsonObject? result = await CallAsync("queues", "get_all_ex", body, cancellationToken);
+        var tasks = (JsonArray?)result?["data"]?["queues"]?[0]?["entries"];
+        IEnumerable<string> taskIds = tasks?.Select(t => (string)t?["id"]!) ?? new List<string>();
+        return await GetTasksByIdAsync(taskIds, cancellationToken);
+    }
+
     public async Task<ClearMLTask?> GetTaskByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         IReadOnlyList<ClearMLTask> tasks = await GetTasksAsync(new JsonObject { ["name"] = name }, cancellationToken);

--- a/src/SIL.Machine.AspNetCore/Services/IClearMLService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/IClearMLService.cs
@@ -20,6 +20,7 @@ public interface IClearMLService
     Task<bool> EnqueueTaskAsync(string id, CancellationToken cancellationToken = default);
     Task<bool> DequeueTaskAsync(string id, CancellationToken cancellationToken = default);
     Task<bool> StopTaskAsync(string id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ClearMLTask>> GetTasksForCurrentQueueAsync(CancellationToken cancellationToken = default);
     Task<ClearMLTask?> GetTaskByNameAsync(string name, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<ClearMLTask>> GetTasksByIdAsync(
         IEnumerable<string> ids,


### PR DESCRIPTION
This solution fetches all tasks queued in the configured queue and unions them with the tasks associated with currently monitored translation engines. This means that there are two additional API calls per `ClearMLMonitorService` run (one to fetch the ids of tasks on the queue and another to fetch the complete info on those tasks). I think this is inevitable because the get-all-queues call only contains information about queued jobs (and, if you dig, currently running jobs), but not jobs that may have failed or completed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/124)
<!-- Reviewable:end -->
