### PR TITLE
Fix null reference return error

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/CancellationInterceptor.cs
+++ b/src/SIL.Machine.AspNetCore/Services/CancellationInterceptor.cs
@@ -24,7 +24,7 @@ public class CancellationInterceptor : Interceptor
             if (ex is OperationCanceledException)
             {
                 _logger.LogInformation("An operation was canceled.");
-                return null;
+                throw new RpcException(new Status(StatusCode.Cancelled, "An operation was canceled."));
             }
             else
             {


### PR DESCRIPTION
Returning a null response from a gRPC `Interceptor` is not allowed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/140)
<!-- Reviewable:end -->
