### PR TITLE
Move logic to parallel text corpus

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
@@ -161,22 +161,7 @@ public class NmtPreprocessBuildJob : HangfireBuildJob<IReadOnlyList<Corpus>>
                         IReadOnlyList<object> refs;
                         if (row.TargetRefs.Count == 0)
                         {
-                            if (targetCorpora[CorpusType.Text] is ScriptureTextCorpus tstc)
-                            {
-                                refs = row
-                                    .SourceRefs.Cast<VerseRef>()
-                                    .Select(srcRef =>
-                                    {
-                                        var trgRef = srcRef.Clone();
-                                        trgRef.ChangeVersification(tstc.Versification);
-                                        return (object)trgRef;
-                                    })
-                                    .ToList();
-                            }
-                            else
-                            {
-                                refs = row.SourceRefs;
-                            }
+                            refs = row.SourceRefs;
                         }
                         else
                         {

--- a/src/SIL.Machine/Corpora/CorporaExtensions.cs
+++ b/src/SIL.Machine/Corpora/CorporaExtensions.cs
@@ -269,7 +269,7 @@ namespace SIL.Machine.Corpora
             return new FlattenTextCorpus(corpusArray);
         }
 
-        public static IEnumerable<(string Text, VerseRef RefCorpusVerseRef, VerseRef? CorpusVerseRef)> ExtractScripture(
+        public static IEnumerable<(string Text, VerseRef RefCorpusVerseRef, VerseRef CorpusVerseRef)> ExtractScripture(
             this ITextCorpus corpus,
             ITextCorpus refCorpus = null
         )
@@ -290,7 +290,7 @@ namespace SIL.Machine.Corpora
                     && vref.CompareTo(curRef.Value, null, compareAllVerses: true, compareSegments: false) != 0
                 )
                 {
-                    yield return (curTrgLineRange ? "<range>" : curTrgLine.ToString(), curRef.Value, curTrgRef);
+                    yield return (curTrgLineRange ? "<range>" : curTrgLine.ToString(), curRef.Value, curTrgRef.Value);
                     curTrgLineRange = curTrgLineRange || curTrgLine.Length > 0;
                     curTrgLine = new StringBuilder();
                     curTrgRef = null;
@@ -348,7 +348,7 @@ namespace SIL.Machine.Corpora
             }
 
             if (curRef.HasValue)
-                yield return (curTrgLineRange ? "<range>" : curTrgLine.ToString(), curRef.Value, curTrgRef);
+                yield return (curTrgLineRange ? "<range>" : curTrgLine.ToString(), curRef.Value, curTrgRef.Value);
         }
 
         private class TransformTextCorpus : TextCorpusBase

--- a/tests/SIL.Machine.Tests/Corpora/CorporaExtensionsTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/CorporaExtensionsTests.cs
@@ -18,6 +18,7 @@ namespace SIL.Machine.Corpora
 
             Assert.That(text, Is.EqualTo(""));
             Assert.That(origRef, Is.EqualTo(new VerseRef("GEN 1:1", ScrVers.Original)));
+            Assert.That(corpusRef, Is.EqualTo(new VerseRef("GEN 1:1", corpus.Versification)));
 
             (text, origRef, corpusRef) = lines[3167];
             Assert.That(text, Is.EqualTo("Chapter fourteen, verse fifty-five. Segment b."));
@@ -32,6 +33,7 @@ namespace SIL.Machine.Corpora
             (text, origRef, corpusRef) = lines[10727];
             Assert.That(text, Is.EqualTo("<range>"));
             Assert.That(origRef, Is.EqualTo(new VerseRef("1CH 12:4", ScrVers.Original)));
+            Assert.That(corpusRef, Is.EqualTo(new VerseRef("1CH 12:4", corpus.Versification)));
 
             (text, origRef, corpusRef) = lines[10731];
             Assert.That(text, Is.EqualTo("<range>"));

--- a/tests/SIL.Machine.Tests/Corpora/CorporaExtensionsTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/CorporaExtensionsTests.cs
@@ -15,9 +15,9 @@ namespace SIL.Machine.Corpora
             Assert.That(lines.Count, Is.EqualTo(41899));
 
             (string text, VerseRef origRef, VerseRef? corpusRef) = lines[0];
+
             Assert.That(text, Is.EqualTo(""));
             Assert.That(origRef, Is.EqualTo(new VerseRef("GEN 1:1", ScrVers.Original)));
-            Assert.That(corpusRef.HasValue, Is.False);
 
             (text, origRef, corpusRef) = lines[3167];
             Assert.That(text, Is.EqualTo("Chapter fourteen, verse fifty-five. Segment b."));
@@ -32,7 +32,6 @@ namespace SIL.Machine.Corpora
             (text, origRef, corpusRef) = lines[10727];
             Assert.That(text, Is.EqualTo("<range>"));
             Assert.That(origRef, Is.EqualTo(new VerseRef("1CH 12:4", ScrVers.Original)));
-            Assert.That(corpusRef.HasValue, Is.False);
 
             (text, origRef, corpusRef) = lines[10731];
             Assert.That(text, Is.EqualTo("<range>"));


### PR DESCRIPTION
When creating a `ParallelTextCorpus`, if target has no references, make target references source references changed to target versification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/169)
<!-- Reviewable:end -->
