### PR TITLE
Remove required property from optional ClearMLTask attributes

### DIFF
--- a/src/SIL.Machine.AspNetCore/Models/ClearMLTask.cs
+++ b/src/SIL.Machine.AspNetCore/Models/ClearMLTask.cs
@@ -20,11 +20,11 @@ public record ClearMLTask
     public required string Name { get; init; }
     public required ClearMLProject Project { get; init; }
     public required ClearMLTaskStatus Status { get; init; }
-    public required string StatusReason { get; init; }
-    public required string StatusMessage { get; init; }
+    public string? StatusReason { get; init; }
+    public string? StatusMessage { get; init; }
     public required DateTime Created { get; init; }
-    public required int LastIteration { get; init; }
-    public required int ActiveDuration { get; init; }
+    public int? LastIteration { get; init; }
+    public int ActiveDuration { get; init; }
     public required IReadOnlyDictionary<
         string,
         IReadOnlyDictionary<string, ClearMLMetricsEvent>

--- a/src/SIL.Machine.AspNetCore/Services/ClearMLMonitorService.cs
+++ b/src/SIL.Machine.AspNetCore/Services/ClearMLMonitorService.cs
@@ -110,7 +110,7 @@ public class ClearMLMonitorService(
                                 platformService,
                                 engine.CurrentBuild.BuildId,
                                 new ProgressStatus(
-                                    task.LastIteration,
+                                    task.LastIteration ?? 0,
                                     percentCompleted: GetMetric(task, SummaryMetric, ProgressVariant)
                                 ),
                                 0,
@@ -122,7 +122,7 @@ public class ClearMLMonitorService(
                             await UpdateTrainJobStatus(
                                 platformService,
                                 engine.CurrentBuild.BuildId,
-                                new ProgressStatus(task.LastIteration, percentCompleted: 1.0),
+                                new ProgressStatus(task.LastIteration ?? 0, percentCompleted: 1.0),
                                 0,
                                 cancellationToken
                             );


### PR DESCRIPTION
All of these properties are technically optional according to the docs. Should we make them all not required? It seems like we might want to avoid processing tasks that, for example, don't have an ID (And I'm not sure how that would ever happen anyways).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/176)
<!-- Reviewable:end -->
