### PR TITLE
Fixes https://github.com/sillsdev/serval/issues/365

### DIFF
--- a/src/SIL.Machine/Scripture/ScriptureRangeParser.cs
+++ b/src/SIL.Machine/Scripture/ScriptureRangeParser.cs
@@ -39,7 +39,7 @@ public class ScriptureRangeParser
         Dictionary<string, List<int>> chaptersPerBook = new Dictionary<string, List<int>>();
 
         //*Specific chapters from one book*
-        if (char.IsDigit(section.Last()))
+        if (char.IsDigit(section.Last()) && section.Length > 3)
         {
             string bookName = section.Substring(0, 3);
             if (!_bookLengths.ContainsKey(bookName))

--- a/tests/SIL.Machine.Tests/Scripture/ScriptureRangeParserTests.cs
+++ b/tests/SIL.Machine.Tests/Scripture/ScriptureRangeParserTests.cs
@@ -27,6 +27,7 @@ public class ScriptureRangeParserTests
     public static IEnumerable<TestCaseData> GetCases()
     {
         yield return new TestCaseData("MAL", new Dictionary<string, List<int>> { { "MAL", new List<int>() } }, false);
+        yield return new TestCaseData("PS2", new Dictionary<string, List<int>> { { "PS2", new List<int>() } }, false);
         yield return new TestCaseData(
             "GEN,EXO",
             new Dictionary<string, List<int>> { { "GEN", new List<int>() }, { "EXO", new List<int>() } },


### PR DESCRIPTION
Fix mis-parsing of chapter selections when book name ends in a digit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/187)
<!-- Reviewable:end -->
