### PR TITLE
Control the pretranslation of existing text

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
@@ -173,7 +173,11 @@ public class NmtPreprocessBuildJob : HangfireBuildJob<IReadOnlyList<Corpus>>
 
             foreach (Row row in AlignPretranslateCorpus(sourceTextCorpora[0], targetTextCorpus))
             {
-                if (IsInPretranslate(row, corpus) && row.SourceSegment.Length > 0 && row.TargetSegment.Length == 0)
+                if (
+                    IsInPretranslate(row, corpus)
+                    && row.SourceSegment.Length > 0
+                    && (row.TargetSegment.Length == 0 || !IsInTrain(row, corpus))
+                )
                 {
                     pretranslateWriter.WriteStartObject();
                     pretranslateWriter.WriteString("corpusId", corpus.Id);

--- a/tests/SIL.Machine.AspNetCore.Tests/Services/NmtPreprocessBuildJobTests.cs
+++ b/tests/SIL.Machine.AspNetCore.Tests/Services/NmtPreprocessBuildJobTests.cs
@@ -58,10 +58,10 @@ public class NmtPreprocessBuildJobTests
     }
 
     [Test]
-    public async Task RunAsync_PretranslateAll()
+    public async Task RunAsync_TrainAndPretranslateAll()
     {
         using TestEnvironment env = new();
-        Corpus corpus1 = env.DefaultTextFileCorpus with { PretranslateAll = true };
+        Corpus corpus1 = env.DefaultTextFileCorpus with { PretranslateAll = true, TrainOnAll = true };
 
         await env.RunBuildJobAsync(corpus1);
 
@@ -69,10 +69,21 @@ public class NmtPreprocessBuildJobTests
     }
 
     [Test]
+    public async Task RunAsync_PretranslateAll()
+    {
+        using TestEnvironment env = new();
+        Corpus corpus1 = env.DefaultTextFileCorpus with { PretranslateAll = true };
+
+        await env.RunBuildJobAsync(corpus1);
+
+        Assert.That(await env.GetPretranslateCountAsync(), Is.EqualTo(4));
+    }
+
+    [Test]
     public async Task RunAsync_PretranslateTextIds()
     {
         using TestEnvironment env = new();
-        Corpus corpus1 = env.DefaultTextFileCorpus with { PretranslateTextIds = ["textId1"] };
+        Corpus corpus1 = env.DefaultTextFileCorpus with { PretranslateTextIds = ["textId1"], TrainOnAll = true };
 
         await env.RunBuildJobAsync(corpus1);
 

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -14,6 +14,9 @@
 \li2 verse four,
 \v 5 Chapter one,
 \li2 verse \fig Figure 1|src="image1.png" size="col" ref="1:5"\fig* five.
+\v 6 Verse 6 content.
+\v 7
+\v 8
 \c 2
 \tr \tc1 Row one, column one. \tc2 Row one, column two.
 \tr \tc1 Row two, column one. \tc2 Row two, column two.

--- a/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
@@ -13,7 +13,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(19));
+        Assert.That(rows, Has.Length.EqualTo(22));
 
         Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:1", corpus.Versification)));
         Assert.That(rows[0].Text, Is.EqualTo("Chapter one, verse one."));
@@ -24,41 +24,41 @@ public class UsfmFileTextTests
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:5", corpus.Versification)));
         Assert.That(rows[4].Text, Is.EqualTo("Chapter one, verse five."));
 
-        Assert.That(rows[5].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
-        Assert.That(rows[5].Text, Is.EqualTo("Chapter two, verse one."));
+        Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
+        Assert.That(rows[8].Text, Is.EqualTo("Chapter two, verse one."));
 
-        Assert.That(rows[6].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:2", corpus.Versification)));
-        Assert.That(rows[6].Text, Is.EqualTo("Chapter two, verse two. Chapter two, verse three."));
-        Assert.That(rows[6].IsInRange, Is.True);
-        Assert.That(rows[6].IsRangeStart, Is.True);
+        Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:2", corpus.Versification)));
+        Assert.That(rows[9].Text, Is.EqualTo("Chapter two, verse two. Chapter two, verse three."));
+        Assert.That(rows[9].IsInRange, Is.True);
+        Assert.That(rows[9].IsRangeStart, Is.True);
 
-        Assert.That(rows[7].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3", corpus.Versification)));
-        Assert.That(rows[7].Text, Is.Empty);
-        Assert.That(rows[7].IsInRange, Is.True);
-        Assert.That(rows[7].IsRangeStart, Is.False);
+        Assert.That(rows[10].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3", corpus.Versification)));
+        Assert.That(rows[10].Text, Is.Empty);
+        Assert.That(rows[10].IsInRange, Is.True);
+        Assert.That(rows[10].IsRangeStart, Is.False);
 
-        Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4a", corpus.Versification)));
-        Assert.That(rows[8].Text, Is.Empty);
-        Assert.That(rows[8].IsInRange, Is.True);
-        Assert.That(rows[7].IsRangeStart, Is.False);
+        Assert.That(rows[11].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4a", corpus.Versification)));
+        Assert.That(rows[11].Text, Is.Empty);
+        Assert.That(rows[11].IsInRange, Is.True);
+        Assert.That(rows[11].IsRangeStart, Is.False);
 
-        Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4b", corpus.Versification)));
-        Assert.That(rows[9].Text, Is.EqualTo("Chapter two, verse four."));
+        Assert.That(rows[12].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4b", corpus.Versification)));
+        Assert.That(rows[12].Text, Is.EqualTo("Chapter two, verse four."));
 
-        Assert.That(rows[10].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:5", corpus.Versification)));
-        Assert.That(rows[10].Text, Is.EqualTo("Chapter two, verse five."));
+        Assert.That(rows[13].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:5", corpus.Versification)));
+        Assert.That(rows[13].Text, Is.EqualTo("Chapter two, verse five."));
 
-        Assert.That(rows[11].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:6", corpus.Versification)));
-        Assert.That(rows[11].Text, Is.EqualTo("Chapter two, verse six."));
+        Assert.That(rows[14].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:6", corpus.Versification)));
+        Assert.That(rows[14].Text, Is.EqualTo("Chapter two, verse six."));
 
-        Assert.That(rows[15].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:9", corpus.Versification)));
-        Assert.That(rows[15].Text, Is.EqualTo("Chapter 2 verse 9"));
+        Assert.That(rows[18].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:9", corpus.Versification)));
+        Assert.That(rows[18].Text, Is.EqualTo("Chapter 2 verse 9"));
 
-        Assert.That(rows[16].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:10", corpus.Versification)));
-        Assert.That(rows[16].Text, Is.EqualTo("Chapter 2 verse 10"));
+        Assert.That(rows[19].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:10", corpus.Versification)));
+        Assert.That(rows[19].Text, Is.EqualTo("Chapter 2 verse 10"));
 
-        Assert.That(rows[17].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:11", corpus.Versification)));
-        Assert.That(rows[17].Text, Is.Empty);
+        Assert.That(rows[20].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:11", corpus.Versification)));
+        Assert.That(rows[20].Text, Is.Empty);
     }
 
     [Test]
@@ -73,7 +73,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(36));
+        Assert.That(rows, Has.Length.EqualTo(39));
 
         Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/1:h", corpus.Versification)));
         Assert.That(rows[0].Text, Is.EqualTo("Matthew"));
@@ -96,35 +96,35 @@ public class UsfmFileTextTests
         Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:2/1:f", corpus.Versification)));
         Assert.That(rows[8].Text, Is.EqualTo("1:2: This is a footnote."));
 
-        Assert.That(rows[12].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/1:tr/1:tc1", corpus.Versification)));
-        Assert.That(rows[12].Text, Is.EqualTo("Row one, column one."));
+        Assert.That(rows[15].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/1:tr/1:tc1", corpus.Versification)));
+        Assert.That(rows[15].Text, Is.EqualTo("Row one, column one."));
 
-        Assert.That(rows[13].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/1:tr/2:tc2", corpus.Versification)));
-        Assert.That(rows[13].Text, Is.EqualTo("Row one, column two."));
+        Assert.That(rows[16].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/1:tr/2:tc2", corpus.Versification)));
+        Assert.That(rows[16].Text, Is.EqualTo("Row one, column two."));
 
-        Assert.That(rows[14].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/2:tr/1:tc1", corpus.Versification)));
-        Assert.That(rows[14].Text, Is.EqualTo("Row two, column one."));
+        Assert.That(rows[17].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/2:tr/1:tc1", corpus.Versification)));
+        Assert.That(rows[17].Text, Is.EqualTo("Row two, column one."));
 
-        Assert.That(rows[15].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/2:tr/2:tc2", corpus.Versification)));
-        Assert.That(rows[15].Text, Is.EqualTo("Row two, column two."));
+        Assert.That(rows[18].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/2:tr/2:tc2", corpus.Versification)));
+        Assert.That(rows[18].Text, Is.EqualTo("Row two, column two."));
 
-        Assert.That(rows[16].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/3:s1", corpus.Versification)));
-        Assert.That(rows[16].Text, Is.EqualTo("Chapter Two"));
+        Assert.That(rows[19].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/3:s1", corpus.Versification)));
+        Assert.That(rows[19].Text, Is.EqualTo("Chapter Two"));
 
-        Assert.That(rows[18].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1/1:f", corpus.Versification)));
-        Assert.That(rows[18].Text, Is.EqualTo("2:1: This is a footnote."));
+        Assert.That(rows[21].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1/1:f", corpus.Versification)));
+        Assert.That(rows[21].Text, Is.EqualTo("2:1: This is a footnote."));
 
-        Assert.That(rows[21].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/1:ms", corpus.Versification)));
-        Assert.That(rows[21].Text, Is.EqualTo("This is a sidebar"));
+        Assert.That(rows[24].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/1:ms", corpus.Versification)));
+        Assert.That(rows[24].Text, Is.EqualTo("This is a sidebar"));
 
-        Assert.That(rows[22].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/2:p", corpus.Versification)));
-        Assert.That(rows[22].Text, Is.EqualTo("Here is some sidebar content."));
+        Assert.That(rows[25].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/2:p", corpus.Versification)));
+        Assert.That(rows[25].Text, Is.EqualTo("Here is some sidebar content."));
 
-        Assert.That(rows[28].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:7a/1:s", corpus.Versification)));
-        Assert.That(rows[28].Text, Is.EqualTo("Section header"));
+        Assert.That(rows[31].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:7a/1:s", corpus.Versification)));
+        Assert.That(rows[31].Text, Is.EqualTo("Section header"));
 
-        Assert.That(rows[35].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:12/1:restore", corpus.Versification)));
-        Assert.That(rows[35].Text, Is.EqualTo("restore information"));
+        Assert.That(rows[38].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:12/1:restore", corpus.Versification)));
+        Assert.That(rows[38].Text, Is.EqualTo("restore information"));
     }
 
     [Test]
@@ -134,7 +134,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(19));
+        Assert.That(rows, Has.Length.EqualTo(22));
 
         Assert.That(rows[3].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:4", corpus.Versification)));
         Assert.That(rows[3].Text, Is.EqualTo("Chapter one, verse four,"));
@@ -167,7 +167,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(19));
+        Assert.That(rows, Has.Length.EqualTo(22));
 
         Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:1", corpus.Versification)));
         Assert.That(
@@ -189,44 +189,44 @@ public class UsfmFileTextTests
             )
         );
 
-        Assert.That(rows[5].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
+        Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
         Assert.That(
-            rows[5].Text,
+            rows[8].Text,
             Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a footnote.\\f*one.")
         );
 
-        Assert.That(rows[6].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:2", corpus.Versification)));
+        Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:2", corpus.Versification)));
         Assert.That(
-            rows[6].Text,
+            rows[9].Text,
             Is.EqualTo("Chapter two, // verse \\fm ∆\\fm*two. Chapter two, verse \\w three|lemma\\w*.")
         );
-        Assert.That(rows[6].IsInRange, Is.True);
-        Assert.That(rows[6].IsRangeStart, Is.True);
+        Assert.That(rows[9].IsInRange, Is.True);
+        Assert.That(rows[9].IsRangeStart, Is.True);
 
-        Assert.That(rows[7].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3", corpus.Versification)));
-        Assert.That(rows[7].Text, Is.Empty);
-        Assert.That(rows[7].IsInRange, Is.True);
-        Assert.That(rows[7].IsRangeStart, Is.False);
+        Assert.That(rows[10].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3", corpus.Versification)));
+        Assert.That(rows[10].Text, Is.Empty);
+        Assert.That(rows[10].IsInRange, Is.True);
+        Assert.That(rows[10].IsRangeStart, Is.False);
 
-        Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4a", corpus.Versification)));
-        Assert.That(rows[8].Text, Is.Empty);
-        Assert.That(rows[8].IsInRange, Is.True);
-        Assert.That(rows[8].IsRangeStart, Is.False);
+        Assert.That(rows[11].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4a", corpus.Versification)));
+        Assert.That(rows[11].Text, Is.Empty);
+        Assert.That(rows[11].IsInRange, Is.True);
+        Assert.That(rows[11].IsRangeStart, Is.False);
 
-        Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4b", corpus.Versification)));
-        Assert.That(rows[9].Text, Is.EqualTo("Chapter two, verse four."));
+        Assert.That(rows[12].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:4b", corpus.Versification)));
+        Assert.That(rows[12].Text, Is.EqualTo("Chapter two, verse four."));
 
-        Assert.That(rows[10].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:5", corpus.Versification)));
-        Assert.That(rows[10].Text, Is.EqualTo("Chapter two, verse five \\rq (MAT 3:1)\\rq*."));
+        Assert.That(rows[13].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:5", corpus.Versification)));
+        Assert.That(rows[13].Text, Is.EqualTo("Chapter two, verse five \\rq (MAT 3:1)\\rq*."));
 
-        Assert.That(rows[11].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:6", corpus.Versification)));
-        Assert.That(rows[11].Text, Is.EqualTo("Chapter two, verse \\w six|strong=\"12345\" \\w*."));
+        Assert.That(rows[14].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:6", corpus.Versification)));
+        Assert.That(rows[14].Text, Is.EqualTo("Chapter two, verse \\w six|strong=\"12345\" \\w*."));
 
-        Assert.That(rows[15].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:9", corpus.Versification)));
-        Assert.That(rows[15].Text, Is.EqualTo("Chapter\\tcr2 2\\tc3 verse\\tcr4 9"));
+        Assert.That(rows[18].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:9", corpus.Versification)));
+        Assert.That(rows[18].Text, Is.EqualTo("Chapter\\tcr2 2\\tc3 verse\\tcr4 9"));
 
-        Assert.That(rows[16].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:10", corpus.Versification)));
-        Assert.That(rows[16].Text, Is.EqualTo("\\tc3-4 Chapter 2 verse 10"));
+        Assert.That(rows[19].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:10", corpus.Versification)));
+        Assert.That(rows[19].Text, Is.EqualTo("\\tc3-4 Chapter 2 verse 10"));
     }
 
     [Test]
@@ -242,7 +242,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(32));
+        Assert.That(rows, Has.Length.EqualTo(35));
 
         Assert.That(rows[2].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip", corpus.Versification)));
         Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew\\fe + \\ft This is an endnote.\\fe*"));
@@ -267,16 +267,16 @@ public class UsfmFileTextTests
             )
         );
 
-        Assert.That(rows[13].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/3:s1", corpus.Versification)));
-        Assert.That(rows[13].Text, Is.EqualTo("Chapter \\it Two \\it*"));
+        Assert.That(rows[16].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/3:s1", corpus.Versification)));
+        Assert.That(rows[16].Text, Is.EqualTo("Chapter \\it Two \\it*"));
 
-        Assert.That(rows[14].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
+        Assert.That(rows[17].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
         Assert.That(
-            rows[14].Text,
+            rows[17].Text,
             Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a footnote.\\f*one.")
         );
 
-        Assert.That(rows[18].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/2:p", corpus.Versification)));
-        Assert.That(rows[18].Text, Is.EqualTo("Here is some sidebar // content."));
+        Assert.That(rows[21].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/2:p", corpus.Versification)));
+        Assert.That(rows[21].Text, Is.EqualTo("Here is some sidebar // content."));
     }
 }

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTextUpdaterTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTextUpdaterTests.cs
@@ -36,6 +36,34 @@ public class UsfmTextUpdaterTests
     }
 
     [Test]
+    public void GetUsfm_PreferExisting()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:6"), "Text 6"),
+            (ScrRef("MAT 1:7"), "Text 7"),
+        };
+        string target = UpdateUsfm(rows, preferExistingText: true);
+        Assert.That(target, Contains.Substring("\\id MAT - Test\r\n"));
+        Assert.That(target, Contains.Substring("\\v 6 Verse 6 content.\r\n"));
+        Assert.That(target, Contains.Substring("\\v 7 Text 7\r\n"));
+    }
+
+    [Test]
+    public void GetUsfm_PreferRows()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:6"), "Text 6"),
+            (ScrRef("MAT 1:7"), "Text 7"),
+        };
+        string target = UpdateUsfm(rows, preferExistingText: false);
+        Assert.That(target, Contains.Substring("\\id MAT - Test\r\n"));
+        Assert.That(target, Contains.Substring("\\v 6 Text 6\r\n"));
+        Assert.That(target, Contains.Substring("\\v 7 Text 7\r\n"));
+    }
+
+    [Test]
     public void GetUsfm_Verse_SkipNote()
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
@@ -340,11 +368,18 @@ public class UsfmTextUpdaterTests
         IReadOnlyList<(IReadOnlyList<ScriptureRef>, string)>? rows = null,
         string? idText = null,
         bool stripAllText = false,
-        bool strictComparison = true
+        bool strictComparison = true,
+        bool preferExistingText = false
     )
     {
         string source = ReadUsfm();
-        var updater = new UsfmTextUpdater(rows, idText, stripAllText, strictComparison);
+        var updater = new UsfmTextUpdater(
+            rows,
+            idText,
+            stripAllText: stripAllText,
+            strictComparison: strictComparison,
+            preferExistingText: preferExistingText
+        );
         UsfmParser.Parse(source, updater);
         return updater.GetUsfm();
     }

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
@@ -11,7 +11,7 @@ public class UsfmTokenizerTests
         string usfm = ReadUsfm();
         var tokenizer = new UsfmTokenizer();
         IReadOnlyList<UsfmToken> tokens = tokenizer.Tokenize(usfm);
-        Assert.That(tokens, Has.Count.EqualTo(170));
+        Assert.That(tokens, Has.Count.EqualTo(174));
 
         Assert.That(tokens[0].Type, Is.EqualTo(UsfmTokenType.Book));
         Assert.That(tokens[0].Marker, Is.EqualTo("id"));


### PR DESCRIPTION
https://github.com/sillsdev/serval/issues/370

Reworked the logic of preferring existing or new text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/189)
<!-- Reviewable:end -->
