### PR TITLE
Fix crash when parsing duplicate verses separated by a paragraph marker

### DIFF
--- a/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
+++ b/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
@@ -54,7 +54,7 @@ namespace SIL.Machine.Corpora
         {
             if (state.VerseRef.Equals(_curVerseRef))
             {
-                EndVerseText(state);
+                EndVerseText(state, CreateVerseRefs());
                 // ignore duplicate verses
                 _duplicateVerse = true;
             }
@@ -83,7 +83,7 @@ namespace SIL.Machine.Corpora
             if (_curVerseRef.IsDefault)
                 UpdateVerseRef(state.VerseRef, marker);
 
-            if (!state.IsVerseText || CurrentTextType == ScriptureTextType.NonVerse)
+            if (!state.IsVerseText || marker == "d")
             {
                 StartParentElement(marker);
                 StartNonVerseText(state);
@@ -174,10 +174,9 @@ namespace SIL.Machine.Corpora
         private void EndVerseText(UsfmParserState state)
         {
             if (!_duplicateVerse && _curVerseRef.VerseNum > 0)
-            {
                 EndVerseText(state, CreateVerseRefs());
+            if (_curVerseRef.VerseNum > 0)
                 _curTextType.Pop();
-            }
         }
 
         private void StartNonVerseText(UsfmParserState state)

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -32,7 +32,9 @@
 \v 4b Chapter two, verse four.
 \p
 \v 6 Chapter two, verse \w six|strong="12345" \w*.
+\p
 \v 6 Bad verse.
+\p
 \v 5 Chapter two, verse five \rq (MAT 3:1)\rq*.
 \v 7a Chapter two, verse seven A,
 \s Section header \ts-s\*

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
@@ -11,7 +11,7 @@ public class UsfmTokenizerTests
         string usfm = ReadUsfm();
         var tokenizer = new UsfmTokenizer();
         IReadOnlyList<UsfmToken> tokens = tokenizer.Tokenize(usfm);
-        Assert.That(tokens, Has.Count.EqualTo(202));
+        Assert.That(tokens, Has.Count.EqualTo(204));
 
         Assert.That(tokens[0].Type, Is.EqualTo(UsfmTokenType.Book));
         Assert.That(tokens[0].Marker, Is.EqualTo("id"));

--- a/tests/SIL.Machine.Tests/Scripture/ScriptureRangeParserTests.cs
+++ b/tests/SIL.Machine.Tests/Scripture/ScriptureRangeParserTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using SIL.Scripture;
 
-namespace SIL.Machine;
+namespace SIL.Machine.Scripture;
 
 [TestFixture]
 public class ScriptureRangeParserTests


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/198)
<!-- Reviewable:end -->
