### PR TITLE
Ignore a note that occurs right after \id marker

### DIFF
--- a/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
+++ b/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
@@ -150,13 +150,17 @@ namespace SIL.Machine.Corpora
 
         public override void StartNote(UsfmParserState state, string marker, string caller, string category)
         {
-            NextElement(marker);
-            StartNoteText(state);
+            if (CurrentTextType != ScriptureTextType.None)
+            {
+                NextElement(marker);
+                StartNoteText(state);
+            }
         }
 
         public override void EndNote(UsfmParserState state, string marker, bool closed)
         {
-            EndNoteText(state);
+            if (CurrentTextType == ScriptureTextType.Note)
+                EndNoteText(state);
         }
 
         public override void Text(UsfmParserState state, string text)

--- a/src/SIL.Machine/Corpora/UsfmTokenizer.cs
+++ b/src/SIL.Machine/Corpora/UsfmTokenizer.cs
@@ -313,6 +313,7 @@ namespace SIL.Machine.Corpora
         {
             UsfmToken prevToken = null;
             var usfm = new StringBuilder();
+            bool inBook = false;
             foreach (UsfmToken token in tokens)
             {
                 string tokenUsfm = "";
@@ -335,6 +336,7 @@ namespace SIL.Machine.Corpora
                                 usfm.Append("\r\n");
                         }
                         tokenUsfm = token.ToUsfm();
+                        inBook = token.Type == UsfmTokenType.Book;
                         break;
                     case UsfmTokenType.Verse:
                         // Add newline if after anything other than [ or (
@@ -359,6 +361,7 @@ namespace SIL.Machine.Corpora
                                 RtlReferenceOrder == RtlReferenceOrder.BookVerseChapter ? "\u200e" : "\u200f";
                             tokenUsfm = RtlVerseRegex.Replace(tokenUsfm, $"$1{directionMarker}$2");
                         }
+                        inBook = false;
                         break;
                     case UsfmTokenType.Text:
                         // Ensure spaces are preserved
@@ -383,7 +386,20 @@ namespace SIL.Machine.Corpora
                         }
                         break;
                     default:
+                        if (inBook)
+                        {
+                            if (
+                                usfm[usfm.Length - 1] == ' '
+                                && ((prevToken != null && prevToken.ToUsfm().Trim() != "") || !tokensHaveWhitespace)
+                            )
+                            {
+                                usfm.Length--;
+                            }
+                            if (!tokensHaveWhitespace)
+                                usfm.Append("\r\n");
+                        }
                         tokenUsfm = token.ToUsfm();
+                        inBook = false;
                         break;
                 }
 

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -1,4 +1,5 @@
 \id MAT - Test
+\f + \fr 1.0 \ft \f*
 \h Matthew
 \mt Matthew
 \ip An introduction to Matthew\fe + \ft This is an endnote.\fe*

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
@@ -11,22 +11,22 @@ public class UsfmTokenizerTests
         string usfm = ReadUsfm();
         var tokenizer = new UsfmTokenizer();
         IReadOnlyList<UsfmToken> tokens = tokenizer.Tokenize(usfm);
-        Assert.That(tokens, Has.Count.EqualTo(218));
+        Assert.That(tokens, Has.Count.EqualTo(224));
 
         Assert.That(tokens[0].Type, Is.EqualTo(UsfmTokenType.Book));
         Assert.That(tokens[0].Marker, Is.EqualTo("id"));
         Assert.That(tokens[0].Data, Is.EqualTo("MAT"));
 
-        Assert.That(tokens[28].Type, Is.EqualTo(UsfmTokenType.Text));
-        Assert.That(tokens[28].Text, Is.EqualTo("Chapter One "));
+        Assert.That(tokens[34].Type, Is.EqualTo(UsfmTokenType.Text));
+        Assert.That(tokens[34].Text, Is.EqualTo("Chapter One "));
 
-        Assert.That(tokens[29].Type, Is.EqualTo(UsfmTokenType.Verse));
-        Assert.That(tokens[29].Marker, Is.EqualTo("v"));
-        Assert.That(tokens[29].Data, Is.EqualTo("1"));
+        Assert.That(tokens[35].Type, Is.EqualTo(UsfmTokenType.Verse));
+        Assert.That(tokens[35].Marker, Is.EqualTo("v"));
+        Assert.That(tokens[35].Data, Is.EqualTo("1"));
 
-        Assert.That(tokens[38].Type, Is.EqualTo(UsfmTokenType.Note));
-        Assert.That(tokens[38].Marker, Is.EqualTo("f"));
-        Assert.That(tokens[38].Data, Is.EqualTo("+"));
+        Assert.That(tokens[44].Type, Is.EqualTo(UsfmTokenType.Note));
+        Assert.That(tokens[44].Marker, Is.EqualTo("f"));
+        Assert.That(tokens[44].Data, Is.EqualTo("+"));
     }
 
     [Test]


### PR DESCRIPTION
- fixes https://github.com/sillsdev/serval/issues/393

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/203)
<!-- Reviewable:end -->
