### PR TITLE
Throw error when both languages are unknown and there's no data

### DIFF
--- a/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
@@ -80,7 +80,7 @@ public class NmtPreprocessBuildJob : HangfireBuildJob<IReadOnlyList<Corpus>>
         if (trainCount == 0 && !tagsInFlores200)
         {
             throw new OperationCanceledException(
-                $"Neither language code in build {buildId} are known to the base model, and the data specified for training was empty. Build Canceled."
+                $"Neither language code in build {buildId} are known to the base model, and the data specified for training was empty. Build canceled."
             );
         }
 

--- a/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
+++ b/src/SIL.Machine.AspNetCore/Services/NmtPreprocessBuildJob.cs
@@ -71,15 +71,21 @@ public class NmtPreprocessBuildJob : HangfireBuildJob<IReadOnlyList<Corpus>>
         if (engine is null)
             throw new OperationCanceledException($"Engine {engineId} does not exist.  Build canceled.");
 
-        bool tagsInFlores200 = _languageTagService.ConvertToFlores200Code(engine.SourceLanguage, out string srcLang);
+        bool sourceTagInFlores200 = _languageTagService.ConvertToFlores200Code(
+            engine.SourceLanguage,
+            out string srcLang
+        );
         buildPreprocessSummary.Add("SourceLanguageResolved", srcLang);
-        tagsInFlores200 &= _languageTagService.ConvertToFlores200Code(engine.TargetLanguage, out string trgLang);
+        bool targetTagInFlores200 = _languageTagService.ConvertToFlores200Code(
+            engine.TargetLanguage,
+            out string trgLang
+        );
         buildPreprocessSummary.Add("TargetLanguageResolved", trgLang);
         Logger.LogInformation("{summary}", buildPreprocessSummary.ToJsonString());
 
-        if (trainCount == 0 && !tagsInFlores200)
+        if (trainCount == 0 && (!sourceTagInFlores200 || !targetTagInFlores200))
         {
-            throw new OperationCanceledException(
+            throw new InvalidOperationException(
                 $"Neither language code in build {buildId} are known to the base model, and the data specified for training was empty. Build canceled."
             );
         }

--- a/tests/SIL.Machine.AspNetCore.Tests/Services/NmtPreprocessBuildJobTests.cs
+++ b/tests/SIL.Machine.AspNetCore.Tests/Services/NmtPreprocessBuildJobTests.cs
@@ -217,7 +217,7 @@ public class NmtPreprocessBuildJobTests
         using TestEnvironment env = new();
         Corpus corpus1 = env.DefaultTextFileCorpus with { SourceLanguage = "xxx", TargetLanguage = "zzz" };
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await env.RunBuildJobAsync(corpus1, engineId: "engine2");
         });


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/284

A couple questions regarding the solution:
1. I noticed that John has it throwing an `OperationCanceledException` when the engine doesn't exist in `NmtPreprocessBuildJob`. Is that what we want? Or should this throw some other exception that would cause the build to be marked as failed instead? And if so, should it also do the same in this case? Maybe I'm missing something. 
2. I thought I'd add a test to cover the logic mentioned above, but it seems to be unreachable because if the engine does not exist, it'll get cut short here in the `HangfireBuildJob` code:  
                `if (!await BuildJobService.BuildJobStartedAsync(engineId, buildId, cancellationToken))
                {
                    completionStatus = JobCompletionStatus.Canceled;
                    return;
                }`
What am I missing?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/205)
<!-- Reviewable:end -->
