### PR TITLE
Recreate the USFM text updating issue in unit tests.

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+!tests/SIL.Machine.Tests/Corpora/TestData/usfm/source/*
+!tests/SIL.Machine.Tests/Corpora/TestData/usfm/target/*

--- a/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
+++ b/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
@@ -150,8 +150,10 @@ namespace SIL.Machine.Corpora
 
         public override void StartNote(UsfmParserState state, string marker, string caller, string category)
         {
-            if (CurrentTextType != ScriptureTextType.None)
+            if (CurrentTextType != ScriptureTextType.None && !_duplicateVerse)
             {
+                // if we hit a note in a verse paragraph and we aren't in a verse, then start a non-verse segment
+                CheckConvertVerseParaToNonVerse(state);
                 NextElement(marker);
                 StartNoteText(state);
             }
@@ -159,26 +161,27 @@ namespace SIL.Machine.Corpora
 
         public override void EndNote(UsfmParserState state, string marker, bool closed)
         {
-            if (CurrentTextType == ScriptureTextType.Note)
+            if (CurrentTextType == ScriptureTextType.Note && !_duplicateVerse)
                 EndNoteText(state);
         }
 
         public override void Text(UsfmParserState state, string text)
         {
             // if we hit text in a verse paragraph and we aren't in a verse, then start a non-verse segment
-            UsfmTag paraTag = state.ParaTag;
-            if (
-                CurrentTextType == ScriptureTextType.None
-                && paraTag != null
-                && paraTag.Marker != "tr"
-                && state.IsVerseText
-                && _curVerseRef.VerseNum == 0
-                && text.Trim().Length > 0
-            )
-            {
-                StartParentElement(paraTag.Marker);
-                StartNonVerseText(state);
-            }
+            if (text.Trim().Length > 0)
+                CheckConvertVerseParaToNonVerse(state);
+        }
+
+        public override void StartChar(
+            UsfmParserState state,
+            string markerWithoutPlus,
+            bool unknown,
+            IReadOnlyList<UsfmAttribute> attributes
+        )
+        {
+            // if we hit a character marker in a verse paragraph and we aren't in a verse, then start a non-verse
+            // segment
+            CheckConvertVerseParaToNonVerse(state);
         }
 
         protected virtual void StartVerseText(UsfmParserState state, IReadOnlyList<ScriptureRef> scriptureRefs) { }
@@ -272,6 +275,22 @@ namespace SIL.Machine.Corpora
                 _curVerseRef.HasMultiple ? _curVerseRef.AllVerses().Last() : _curVerseRef,
                 _curElements.Where(e => e.Position > 0).Reverse()
             );
+        }
+
+        private void CheckConvertVerseParaToNonVerse(UsfmParserState state)
+        {
+            UsfmTag paraTag = state.ParaTag;
+            if (
+                CurrentTextType == ScriptureTextType.None
+                && paraTag != null
+                && paraTag.Marker != "tr"
+                && state.IsVersePara
+                && _curVerseRef.VerseNum == 0
+            )
+            {
+                StartParentElement(paraTag.Marker);
+                StartNonVerseText(state);
+            }
         }
     }
 }

--- a/src/SIL.Machine/Corpora/UsfmParser.cs
+++ b/src/SIL.Machine/Corpora/UsfmParser.cs
@@ -153,6 +153,9 @@ namespace SIL.Machine.Corpora
             // Move to next token
             State.Index++;
 
+            State.LineNumber = State.Token.LineNumber;
+            State.ColumnNumber = State.Token.ColumnNumber;
+
             // Update verse offset with previous token (since verse offset is from start of current token)
             if (State.PrevToken != null)
                 State.VerseOffset += State.PrevToken.GetLength(addSpaces: !TokensPreserveWhitespace);

--- a/src/SIL.Machine/Corpora/UsfmParserState.cs
+++ b/src/SIL.Machine/Corpora/UsfmParserState.cs
@@ -19,6 +19,8 @@ namespace SIL.Machine.Corpora
             _stack = new List<UsfmParserElement>();
             VerseRef = new VerseRef(versification);
             VerseOffset = 0;
+            LineNumber = 1;
+            ColumnNumber = 0;
             Tokens = tokens;
         }
 
@@ -58,6 +60,9 @@ namespace SIL.Machine.Corpora
         /// Offset of start of token in verse
         /// </summary>
         public int VerseOffset { get; internal set; }
+
+        public int LineNumber { get; internal set; }
+        public int ColumnNumber { get; internal set; }
 
         /// <summary>
         /// True if the token processed is part of a special indivisible group

--- a/src/SIL.Machine/Corpora/UsfmTextBase.cs
+++ b/src/SIL.Machine/Corpora/UsfmTextBase.cs
@@ -53,9 +53,8 @@ namespace SIL.Machine.Corpora
                 sb.Append($"An error occurred while parsing the text '{Id}`");
                 if (!string.IsNullOrEmpty(Project))
                     sb.Append($" in project '{Project}'");
-                sb.Append(
-                    $". Verse: {parser.State.VerseRef}, offset: {parser.State.VerseOffset}, error: '{ex.Message}'"
-                );
+                sb.Append($". Verse: {parser.State.VerseRef}, line: {parser.State.LineNumber}, ");
+                sb.Append($"column: {parser.State.ColumnNumber}, error: '{ex.Message}'");
                 throw new InvalidOperationException(sb.ToString(), ex);
             }
             return rowCollector.Rows;
@@ -167,6 +166,9 @@ namespace SIL.Machine.Corpora
             )
             {
                 base.EndChar(state, marker, attributes, closed);
+
+                if (_rowTexts.Count == 0)
+                    return;
 
                 if (_text._includeMarkers && attributes != null && state.PrevToken?.Type == UsfmTokenType.Attribute)
                     _rowTexts.Peek().Append(state.PrevToken);

--- a/src/SIL.Machine/Corpora/UsfmToken.cs
+++ b/src/SIL.Machine/Corpora/UsfmToken.cs
@@ -55,6 +55,8 @@ namespace SIL.Machine.Corpora
 
         public string Data { get; }
 
+        public int LineNumber { get; internal set; } = -1;
+        public int ColumnNumber { get; internal set; } = -1;
         public IReadOnlyList<UsfmAttribute> Attributes { get; private set; }
 
         public string NestlessMarker

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -3,7 +3,7 @@
 \h Matthew
 \mt Matthew
 \ip An introduction to Matthew\fe + \ft This is an endnote.\fe*
-\p Here is another paragraph.
+\p \rq MAT 1\rq* Here is another paragraph.
 \p and with a \w keyword|a special concept\w* in it.
 \p and a \weirdtaglookingthing that is not an actual tag.
 \c 1
@@ -38,7 +38,7 @@
 \p
 \v 6 Chapter two, verse \w six|strong="12345" \w*.
 \p
-\v 6 Bad verse.
+\v 6 Bad verse. \x - \xo abc\xt 123\x* and more content.
 \p
 \v 5 Chapter two, verse five \rq (MAT 3:1)\rq*.
 \v 7a Chapter two, verse seven A,

--- a/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
@@ -88,7 +88,7 @@ public class UsfmFileTextTests
         Assert.That(rows[3].Text, Is.EqualTo("This is an endnote."));
 
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/4:p", corpus.Versification)));
-        Assert.That(rows[4].Text, Is.EqualTo("Here is another paragraph."));
+        Assert.That(rows[4].Text, Is.EqualTo("MAT 1 Here is another paragraph."));
 
         Assert.That(
             rows[7].Ref,

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
@@ -11,22 +11,30 @@ public class UsfmTokenizerTests
         string usfm = ReadUsfm();
         var tokenizer = new UsfmTokenizer();
         IReadOnlyList<UsfmToken> tokens = tokenizer.Tokenize(usfm);
-        Assert.That(tokens, Has.Count.EqualTo(224));
+        Assert.That(tokens, Has.Count.EqualTo(234));
 
         Assert.That(tokens[0].Type, Is.EqualTo(UsfmTokenType.Book));
         Assert.That(tokens[0].Marker, Is.EqualTo("id"));
         Assert.That(tokens[0].Data, Is.EqualTo("MAT"));
+        Assert.That(tokens[0].LineNumber, Is.EqualTo(1));
+        Assert.That(tokens[0].ColumnNumber, Is.EqualTo(1));
 
-        Assert.That(tokens[34].Type, Is.EqualTo(UsfmTokenType.Text));
-        Assert.That(tokens[34].Text, Is.EqualTo("Chapter One "));
+        Assert.That(tokens[37].Type, Is.EqualTo(UsfmTokenType.Text));
+        Assert.That(tokens[37].Text, Is.EqualTo("Chapter One "));
+        Assert.That(tokens[37].LineNumber, Is.EqualTo(10));
+        Assert.That(tokens[37].ColumnNumber, Is.EqualTo(4));
 
-        Assert.That(tokens[35].Type, Is.EqualTo(UsfmTokenType.Verse));
-        Assert.That(tokens[35].Marker, Is.EqualTo("v"));
-        Assert.That(tokens[35].Data, Is.EqualTo("1"));
+        Assert.That(tokens[38].Type, Is.EqualTo(UsfmTokenType.Verse));
+        Assert.That(tokens[38].Marker, Is.EqualTo("v"));
+        Assert.That(tokens[38].Data, Is.EqualTo("1"));
+        Assert.That(tokens[38].LineNumber, Is.EqualTo(11));
+        Assert.That(tokens[38].ColumnNumber, Is.EqualTo(1));
 
-        Assert.That(tokens[44].Type, Is.EqualTo(UsfmTokenType.Note));
-        Assert.That(tokens[44].Marker, Is.EqualTo("f"));
-        Assert.That(tokens[44].Data, Is.EqualTo("+"));
+        Assert.That(tokens[47].Type, Is.EqualTo(UsfmTokenType.Note));
+        Assert.That(tokens[47].Marker, Is.EqualTo("f"));
+        Assert.That(tokens[47].Data, Is.EqualTo("+"));
+        Assert.That(tokens[47].LineNumber, Is.EqualTo(11));
+        Assert.That(tokens[47].ColumnNumber, Is.EqualTo(52));
     }
 
     [Test]


### PR DESCRIPTION
Make USFM updating errors more explicit: https://github.com/sillsdev/serval/issues/398

@ddaspit  - can up finish resolving the USFM updating parse stack empty issue?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/206)
<!-- Reviewable:end -->
