### PR TITLE
Remove duplicate test

### DIFF
--- a/tests/SIL.Machine.Tests/Corpora/ParatextProjectTermsParserTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParatextProjectTermsParserTests.cs
@@ -73,21 +73,6 @@ public class ParatextProjectTermsParserTests
     }
 
     [Test]
-    public void TestGetKeyTermsFromTermsLocalizations_NoTermRenderings_PreferLocalization()
-    {
-        var env = new TestEnvironment(
-            new DefaultParatextProjectSettings(
-                biblicalTermsListType: "Major",
-                biblicalTermsFileName: "BiblicalTerms.xml"
-            ),
-            useTermGlosses: true
-        );
-        IEnumerable<(string TermId, IReadOnlyList<string> Glosses)> terms = env.GetGlosses();
-        Assert.That(terms.Count, Is.EqualTo(5726));
-        Assert.That(string.Join(" ", terms.First().Glosses), Is.EqualTo("Abagtha"));
-    }
-
-    [Test]
     public void TestGetKeyTermsFromTermsLocalizations_()
     {
         var env = new TestEnvironment(


### PR DESCRIPTION
Matthew brought to my attention in his porting that there were some tests that became duplicates of each other after changes to the options regarding using glosses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/237)
<!-- Reviewable:end -->
