### PR TITLE
LT-21911: Fix problem that suppressed homographs

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -364,9 +364,9 @@ namespace SIL.Machine.Morphology.HermitCrab
                 _traceManager.LexicalLookup(input.Stratum, input);
             CharacterDefinitionTable table = input.Stratum.CharacterDefinitionTable;
             IEnumerable<ShapeNode> shapeNodes = input.Shape.GetNodes(input.Range);
-            HashSet<string> shapeSet = new HashSet<string>();
             foreach (RootAllomorph lexicalPattern in _lexicalPatterns)
             {
+                HashSet<string> shapeSet = new HashSet<string>();
                 IEnumerable<ShapeNode> shapePattern = lexicalPattern.Segments.Shape.GetNodes(
                     lexicalPattern.Segments.Shape.Range
                 );


### PR DESCRIPTION
Beth reported that the novel root guesser couldn't handle homographs (e.g. two lexical entries that looked like [Seg]*).  This was because there was code to suppress duplicate paths through a pattern, but the scope was too big.  Narrowing the scope fixed the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/259)
<!-- Reviewable:end -->
