### PR TITLE
Fix LT-21939

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisAffixProcessAllomorphRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisAffixProcessAllomorphRuleSpec.cs
@@ -165,7 +165,13 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 _allomorph,
                 output.MorphologicalRuleApplicationCount.ToString()
             );
-
+            if (outputNewMorph == null)
+            {
+                // There are no new output morphs in a truncation rule,
+                // so we add its allomorph to the last output shape.
+                 string morphID = output.MorphologicalRuleApplicationCount.ToString();
+                output.MarkMorph(new List<ShapeNode>() { output.Shape.Last }, _allomorph, morphID);
+            }
             var markedAllomorphs = new HashSet<Allomorph>();
             foreach (Annotation<ShapeNode> inputMorph in match.Input.Morphs)
             {
@@ -178,11 +184,20 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 }
                 else if (inputMorph.Parent == null && !markedAllomorphs.Contains(allomorph))
                 {
-                    // an existing morph has been completely subsumed by the new morph
-                    // mark the subsumed morph so we don't lose track of it
-                    // this is only necessary if the allomorph hasn't already been marked elsewhere
-                    Annotation<ShapeNode> outputMorph = output.MarkSubsumedMorph(outputNewMorph, allomorph, morphID);
-                    MarkSubsumedMorphs(match.Input, output, inputMorph, outputMorph);
+                    // This is only necessary if the allomorph hasn't already been marked elsewhere.
+                    if (outputNewMorph == null)
+                    {
+                        // There are no new output morphs in a truncation rule,
+                        // So we add allomorph to the first output shape.
+                        output.MarkMorph(new List<ShapeNode>() { output.Shape.First }, allomorph, morphID);
+                    }
+                    else
+                    {
+                        // an existing morph has been completely subsumed by the new morph
+                        // mark the subsumed morph so we don't lose track of it
+                        Annotation<ShapeNode> outputMorph = output.MarkSubsumedMorph(outputNewMorph, allomorph, morphID);
+                        MarkSubsumedMorphs(match.Input, output, inputMorph, outputMorph);
+                    }
                 }
                 markedAllomorphs.Add(allomorph);
             }

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorphologicalRules/AffixProcessRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorphologicalRules/AffixProcessRuleTests.cs
@@ -1192,7 +1192,7 @@ public class AffixProcessRuleTests : HermitCrabTestBase
         Morphophonemic.MorphologicalRules.Add(truncate);
 
         var morpher = new Morpher(TraceManager, Language);
-        AssertMorphsEqual(morpher.ParseWord("sa"), "32");
+        AssertMorphsEqual(morpher.ParseWord("sa"), "32 3SG");
 
         truncate.Allomorphs.Clear();
         truncate.Allomorphs.Add(
@@ -1208,7 +1208,7 @@ public class AffixProcessRuleTests : HermitCrabTestBase
         );
 
         morpher = new Morpher(TraceManager, Language);
-        AssertMorphsEqual(morpher.ParseWord("ag"), "32");
+        AssertMorphsEqual(morpher.ParseWord("ag"), "32 3SG");
 
         truncate.Allomorphs.Clear();
         truncate.Allomorphs.Add(
@@ -1224,7 +1224,7 @@ public class AffixProcessRuleTests : HermitCrabTestBase
         );
 
         morpher = new Morpher(TraceManager, Language);
-        AssertMorphsEqual(morpher.ParseWord("ag"), "32");
+        AssertMorphsEqual(morpher.ParseWord("ag"), "32 3SG");
 
         truncate.Allomorphs.Clear();
         truncate.Allomorphs.Add(
@@ -1240,7 +1240,7 @@ public class AffixProcessRuleTests : HermitCrabTestBase
         );
 
         morpher = new Morpher(TraceManager, Language);
-        AssertMorphsEqual(morpher.ParseWord("sa"), "32");
+        AssertMorphsEqual(morpher.ParseWord("sa"), "32 3SG");
 
         truncate.Allomorphs.Clear();
         truncate.Allomorphs.Add(
@@ -1866,10 +1866,32 @@ public class AffixProcessRuleTests : HermitCrabTestBase
         );
         Morphophonemic.MorphologicalRules.Add(nominalizer);
 
+        var deleteVowelSuffix = new AffixProcessRule
+        {
+            Name = "delete_vowel_suffix",
+            Gloss = "PRES",
+            RequiredSyntacticFeatureStruct = FeatureStruct.New(Language.SyntacticFeatureSystem).Symbol("V").Value,
+        };
+        deleteVowelSuffix.Allomorphs.Add(
+            new AffixProcessAllomorph
+            {
+                Lhs =
+                {
+                    Pattern<Word, ShapeNode>.New("1").Annotation(any).OneOrMore.Value,
+                    Pattern<Word, ShapeNode>.New("2").Annotation(vowel).Value
+                },
+                Rhs = { new CopyFromInput("1") }
+            }
+        );
+        Morphophonemic.MorphologicalRules.Add(deleteVowelSuffix);
+
         var morpher = new Morpher(TraceManager, Language);
         AssertMorphsEqual(morpher.ParseWord("tagu"), "47 3SG");
         AssertMorphsEqual(morpher.ParseWord("tags"), "47 3SG PAST");
         AssertMorphsEqual(morpher.ParseWord("tagsv"), "47 3SG PAST NOM");
+        // Test deleteVowelSuffix.
+        AssertMorphsEqual(morpher.ParseWord("tag"), "47 3SG PRES", "47");
+        AssertMorphsEqual(morpher.ParseWord("bubib"), "42 PRES", "43 PRES");
     }
 
     [Test]


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-21939.  I was able to reproduce the bug by adding an APR to a unit test (deleteVowelSuffix in AffixProcessRuleTests.SubsumedAffix), and then I tried different modifications to the code until it passed the unit test.  In the process, I discovered what I think is a bug related to the TruncateRules test, which is that the code was not recording the truncate rule in the output even though it was needed to parse words.  I hope that this is correct.