### PR TITLE
Fix bug with MorphologicalRuleOrder.Linear for LT-21988

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -69,17 +69,8 @@ namespace SIL.Machine.Morphology.HermitCrab
             _prulesRule.Apply(input);
             input.Freeze();
 
-            IEnumerable<Word> mruleOutWords = null;
-            switch (_stratum.MorphologicalRuleOrder)
-            {
-                case MorphologicalRuleOrder.Linear:
-                    mruleOutWords = ApplyTemplates(input);
-                    break;
-
-                case MorphologicalRuleOrder.Unordered:
-                    mruleOutWords = ApplyTemplates(input).Concat(ApplyMorphologicalRules(input));
-                    break;
-            }
+            // AnalysisStratumRule.Apply should cover the inverse of SynthesisStratumRule.Apply.
+            IEnumerable<Word> mruleOutWords = ApplyTemplates(input).Concat(ApplyMorphologicalRules(input));
             Debug.Assert(mruleOutWords != null);
 
             var output = new HashSet<Word>(FreezableEqualityComparer<Word>.Default) { input };

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/HermitCrabTestBase.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/HermitCrabTestBase.cs
@@ -813,6 +813,15 @@ public abstract class HermitCrabTestBase
             stratum.MorphologicalRules.Clear();
             stratum.AffixTemplates.Clear();
         }
+        SetRuleOrder(MorphologicalRuleOrder.Unordered);
+    }
+
+    protected void SetRuleOrder(MorphologicalRuleOrder ruleOrder)
+    {
+        foreach (Stratum stratum in Language.Strata)
+        {
+            stratum.MorphologicalRuleOrder = ruleOrder;
+       }
     }
 
     public LexEntry AddEntry(string gloss, FeatureStruct syntacticFS, Stratum stratum, params string[] forms)

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/HermitCrabTestBase.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/HermitCrabTestBase.cs
@@ -821,7 +821,7 @@ public abstract class HermitCrabTestBase
         foreach (Stratum stratum in Language.Strata)
         {
             stratum.MorphologicalRuleOrder = ruleOrder;
-       }
+        }
     }
 
     public LexEntry AddEntry(string gloss, FeatureStruct syntacticFS, Stratum stratum, params string[] forms)

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
@@ -36,6 +36,12 @@ public class MorpherTests : HermitCrabTestBase
             morpher.AnalyzeWord("sagd"),
             Is.EquivalentTo(new[] { new WordAnalysis(new IMorpheme[] { Entries["32"], edSuffix }, 0, "V") })
         );
+
+        SetRuleOrder(MorphologicalRuleOrder.Linear);
+        Assert.That(
+            morpher.AnalyzeWord("sagd"),
+            Is.EquivalentTo(new[] { new WordAnalysis(new IMorpheme[] { Entries["32"], edSuffix }, 0, "V") })
+        );
     }
 
     [Test]


### PR DESCRIPTION
There was a bug in AnalysisStratumRule.Apply when the MorphologicalRuleOrder was Linear.  It did not include the case where there were morphological rules but no templates.  This did not match what SynthesisStratumRule.Apply was doing.  I fixed the bug and extended a unit test to cover this case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/279)
<!-- Reviewable:end -->
