### PR TITLE
Fix another bug with MorphologicalRuleOrder.Linear

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -34,7 +34,11 @@ namespace SIL.Machine.Morphology.HermitCrab
             switch (stratum.MorphologicalRuleOrder)
             {
                 case MorphologicalRuleOrder.Linear:
-                    _mrulesRule = new LinearRuleCascade<Word, ShapeNode>(
+                    // Use PermutationRuleCascade instead of LinearRuleCascade
+                    // because morphological rules should be considered optional
+                    // during unapplication (they are obligatory during application,
+                    // but we don't know they have been applied during unapplication).
+                    _mrulesRule = new PermutationRuleCascade<Word, ShapeNode>(
                         mrules,
                         true,
                         FreezableEqualityComparer<Word>.Default

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
@@ -85,10 +85,7 @@ public class MorpherTests : HermitCrabTestBase
             Lhs = Pattern<Word, ShapeNode>.New().Annotation(Character(Table1, "t")).Value
         };
         rule1.Subrules.Add(
-            new RewriteSubrule
-            {
-                Rhs = Pattern<Word, ShapeNode>.New().Annotation(Character(Table1, "d")).Value,
-            }
+            new RewriteSubrule { Rhs = Pattern<Word, ShapeNode>.New().Annotation(Character(Table1, "d")).Value }
         );
         Morphophonemic.PhonologicalRules.Add(rule1);
 


### PR DESCRIPTION
There was a bug in how unapplication worked for morphological rules with MorphologicalRuleOrder.Linear.  I created a test case that provoked the bug, and then I fixed the bug by using PermutationRuleOrder instead of LinearRuleOrder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/280)
<!-- Reviewable:end -->
