### PR TITLE
Do not translate markers

### DIFF
--- a/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
+++ b/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
@@ -23,7 +23,9 @@ namespace SIL.Machine.Corpora
             string bookId,
             IReadOnlyList<(IReadOnlyList<ScriptureRef>, string)> rows,
             string fullName = null,
-            UpdateUsfmBehavior behavior = UpdateUsfmBehavior.PreferExisting
+            UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferExisting,
+            UpdateUsfmIntraVerseMarkerBehavior embedBehavior = UpdateUsfmIntraVerseMarkerBehavior.Preserve,
+            UpdateUsfmIntraVerseMarkerBehavior styleBehavior = UpdateUsfmIntraVerseMarkerBehavior.Strip
         )
         {
             string fileName = _settings.GetBookFileName(bookId);
@@ -36,7 +38,13 @@ namespace SIL.Machine.Corpora
                 usfm = reader.ReadToEnd();
             }
 
-            var handler = new UpdateUsfmParserHandler(rows, fullName is null ? null : $"- {fullName}", behavior);
+            var handler = new UpdateUsfmParserHandler(
+                rows,
+                fullName is null ? null : $"- {fullName}",
+                textBehavior,
+                embedBehavior,
+                styleBehavior
+            );
             try
             {
                 UsfmParser.Parse(usfm, handler, _settings.Stylesheet, _settings.Versification);

--- a/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
+++ b/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
@@ -24,8 +24,8 @@ namespace SIL.Machine.Corpora
             IReadOnlyList<(IReadOnlyList<ScriptureRef>, string)> rows,
             string fullName = null,
             UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferExisting,
-            UpdateUsfmIntraVerseMarkerBehavior embedBehavior = UpdateUsfmIntraVerseMarkerBehavior.Preserve,
-            UpdateUsfmIntraVerseMarkerBehavior styleBehavior = UpdateUsfmIntraVerseMarkerBehavior.Strip
+            UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
+            UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip
         )
         {
             string fileName = _settings.GetBookFileName(bookId);

--- a/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
+++ b/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
@@ -22,7 +22,7 @@ namespace SIL.Machine.Corpora
         private bool _duplicateVerse = false;
 
         private bool _inEmbed;
-        public bool InNoteText { get; private set; }
+        protected bool InNoteText { get; private set; }
         private bool _inNestedEmbed;
 
         protected ScriptureRefUsfmParserHandlerBase()
@@ -168,12 +168,12 @@ namespace SIL.Machine.Corpora
 
         public override void EndNote(UsfmParserState state, string marker, bool closed)
         {
-            EndNoteText(state);
+            EndNoteTextWrapper(state);
             EndEmbed(state, marker, null, closed);
             _inEmbed = false;
         }
 
-        public void StartEmbed(UsfmParserState state, string marker)
+        protected void StartEmbed(UsfmParserState state, string marker)
         {
             if (_curVerseRef.IsDefault)
                 UpdateVerseRef(state.VerseRef, marker);
@@ -188,9 +188,9 @@ namespace SIL.Machine.Corpora
             StartEmbed(state, CreateNonVerseRef());
         }
 
-        public virtual void StartEmbed(UsfmParserState state, ScriptureRef scriptureRef) { }
+        protected virtual void StartEmbed(UsfmParserState state, ScriptureRef scriptureRef) { }
 
-        public virtual void EndEmbed(
+        protected virtual void EndEmbed(
             UsfmParserState state,
             string marker,
             IReadOnlyList<UsfmAttribute> attributes,
@@ -250,7 +250,7 @@ namespace SIL.Machine.Corpora
                 }
                 else
                 {
-                    EndNoteText(state);
+                    EndNoteTextWrapper(state);
                 }
             }
             if (IsEmbedStyle(marker))
@@ -268,7 +268,7 @@ namespace SIL.Machine.Corpora
 
         protected virtual void EndNonVerseText(UsfmParserState state, ScriptureRef scriptureRef) { }
 
-        public virtual void StartNoteTextWrapper(UsfmParserState state)
+        protected virtual void StartNoteTextWrapper(UsfmParserState state)
         {
             InNoteText = true;
             _curTextType.Push(ScriptureTextType.NoteText);
@@ -277,7 +277,7 @@ namespace SIL.Machine.Corpora
 
         protected virtual void StartNoteText(UsfmParserState state) { }
 
-        public virtual void EndNoteText(UsfmParserState state)
+        protected virtual void EndNoteTextWrapper(UsfmParserState state)
         {
             if (_curTextType.Count > 0 && _curTextType.Peek() == ScriptureTextType.NoteText)
             {
@@ -381,12 +381,12 @@ namespace SIL.Machine.Corpora
             }
         }
 
-        public bool InEmbed(string marker)
+        protected bool IsInEmbed(string marker)
         {
             return _inEmbed || IsEmbedStyle(marker);
         }
 
-        public bool IsInNestedEmbed(string marker)
+        protected bool IsInNestedEmbed(string marker)
         {
             return _inNestedEmbed
                 || (
@@ -397,17 +397,17 @@ namespace SIL.Machine.Corpora
                 );
         }
 
-        private static bool IsNoteText(string marker)
+        protected static bool IsNoteText(string marker)
         {
             return marker == "ft";
         }
 
-        public static bool IsEmbedPartStyle(string marker)
+        protected static bool IsEmbedPartStyle(string marker)
         {
             return !(marker is null) && marker.Length > 0 && marker[0].IsOneOf(EmbedPartStartCharStyles);
         }
 
-        private static bool IsEmbedStyle(string marker)
+        protected static bool IsEmbedStyle(string marker)
         {
             return !(marker is null) && marker.IsOneOf(EmbedStyles);
         }

--- a/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
+++ b/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
@@ -385,7 +385,7 @@ namespace SIL.Machine.Corpora
             string marker = state?.Token?.Marker;
             bool inEmbed = InEmbed(marker);
             bool inNestedEmbed = IsInNestedEmbed(marker);
-            bool isStyleTag = marker != null && !IsEmbedPart(marker);
+            bool isStyleTag = marker != null && !IsEmbedPartStyle(marker);
 
             bool existingText = state
                 .Tokens.Skip(_tokenIndex)

--- a/src/SIL.Machine/Corpora/UsfmStylesheet.cs
+++ b/src/SIL.Machine/Corpora/UsfmStylesheet.cs
@@ -111,7 +111,7 @@ namespace SIL.Machine.Corpora
             return false;
         }
 
-        private static IEnumerable<string> GetEmbeddedStylesheet(string fileName)
+        private static IEnumerable<string> GetEmbedStylesheet(string fileName)
         {
             using (
                 var reader = new StreamReader(
@@ -136,7 +136,7 @@ namespace SIL.Machine.Corpora
             {
                 string fileName = Path.GetFileName(stylesheetFileName);
                 if (fileName == "usfm.sty" || fileName == "usfm_sb.sty")
-                    lines = GetEmbeddedStylesheet(fileName);
+                    lines = GetEmbedStylesheet(fileName);
                 else
                     throw new ArgumentException("The stylesheet does not exist.", nameof(stylesheetFileName));
             }

--- a/src/SIL.Machine/Corpora/UsfmStylesheet.cs
+++ b/src/SIL.Machine/Corpora/UsfmStylesheet.cs
@@ -111,7 +111,7 @@ namespace SIL.Machine.Corpora
             return false;
         }
 
-        private static IEnumerable<string> GetEmbedStylesheet(string fileName)
+        private static IEnumerable<string> GetEmbeddedStylesheet(string fileName)
         {
             using (
                 var reader = new StreamReader(
@@ -136,7 +136,7 @@ namespace SIL.Machine.Corpora
             {
                 string fileName = Path.GetFileName(stylesheetFileName);
                 if (fileName == "usfm.sty" || fileName == "usfm_sb.sty")
-                    lines = GetEmbedStylesheet(fileName);
+                    lines = GetEmbeddedStylesheet(fileName);
                 else
                     throw new ArgumentException("The stylesheet does not exist.", nameof(stylesheetFileName));
             }

--- a/src/SIL.Machine/Corpora/UsfmTextBase.cs
+++ b/src/SIL.Machine/Corpora/UsfmTextBase.cs
@@ -258,7 +258,9 @@ namespace SIL.Machine.Corpora
                 }
                 else if (text.Length > 0 && (CurrentTextType != ScriptureTextType.Verse || state.IsVerseText))
                 {
-                    if (InEmbed(state.Token.Marker) && (!InNoteText || IsInNestedEmbed(state.Token.Marker)))
+                    bool isEmbedOrNestedDontUpdate =
+                        InEmbed(state.Token.Marker) && (!InNoteText || IsInNestedEmbed(state.Token.Marker));
+                    if (isEmbedOrNestedDontUpdate)
                         return;
 
                     if (

--- a/src/SIL.Machine/Corpora/UsfmTextBase.cs
+++ b/src/SIL.Machine/Corpora/UsfmTextBase.cs
@@ -258,6 +258,9 @@ namespace SIL.Machine.Corpora
                 }
                 else if (text.Length > 0 && (CurrentTextType != ScriptureTextType.Verse || state.IsVerseText))
                 {
+                    if (InEmbed(state.Token.Marker) && !InNoteText)
+                        return;
+
                     if (
                         state.PrevToken?.Type == UsfmTokenType.End
                         && (rowText.Length == 0 || char.IsWhiteSpace(rowText[rowText.Length - 1]))

--- a/src/SIL.Machine/Corpora/UsfmTextBase.cs
+++ b/src/SIL.Machine/Corpora/UsfmTextBase.cs
@@ -258,7 +258,7 @@ namespace SIL.Machine.Corpora
                 }
                 else if (text.Length > 0 && (CurrentTextType != ScriptureTextType.Verse || state.IsVerseText))
                 {
-                    if (InEmbed(state.Token.Marker) && !InNoteText)
+                    if (InEmbed(state.Token.Marker) && (!InNoteText || IsInNestedEmbed(state.Token.Marker)))
                         return;
 
                     if (
@@ -296,7 +296,7 @@ namespace SIL.Machine.Corpora
                     _rows.Add(_text.CreateRow(scriptureRef, text, _sentenceStart));
             }
 
-            protected override void StartNoteText(UsfmParserState state, ScriptureRef scriptureRef)
+            protected override void StartNoteText(UsfmParserState state)
             {
                 if (_text._includeMarkers)
                     return;

--- a/src/SIL.Machine/Corpora/UsfmTextBase.cs
+++ b/src/SIL.Machine/Corpora/UsfmTextBase.cs
@@ -259,7 +259,7 @@ namespace SIL.Machine.Corpora
                 else if (text.Length > 0 && (CurrentTextType != ScriptureTextType.Verse || state.IsVerseText))
                 {
                     bool isEmbedOrNestedDontUpdate =
-                        InEmbed(state.Token.Marker) && (!InNoteText || IsInNestedEmbed(state.Token.Marker));
+                        IsInEmbed(state.Token.Marker) && (!InNoteText || IsInNestedEmbed(state.Token.Marker));
                     if (isEmbedOrNestedDontUpdate)
                         return;
 

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -13,7 +13,7 @@
 \li2 verse\f + \fr 1:2: \ft This is a footnote for v2.\f* two.
 \v 3 Chapter one \w*,
 \li2 verse three.
-\v 4 Chapter one,
+\v 4 Chapter one with odd whitespace, 
 \li2 verse four,
 \v 5 Chapter one,
 \li2 verse \fig Figure 1|src="image1.png" size="col" ref="1:5"\fig* five.

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -1,20 +1,19 @@
 \id MAT - Test
-\f + \fr 1.0 \ft \f*
 \h Matthew
 \mt Matthew
-\ip An introduction to Matthew\fe + \ft This is an endnote.\fe*
+\ip An introduction to Matthew with an empty comment\fe + \ft \fe*
 \p \rq MAT 1\rq* Here is another paragraph.
 \p and with a \w keyword|a special concept\w* in it.
 \p and a \weirdtaglookingthing that is not an actual tag.
 \c 1
 \s Chapter One
-\v 1 Chapter \pn one\+pro WON\+pro*\pn*, verse one.\f + \fr 1:1: \ft This is a footnote.\f*
+\v 1 Chapter \pn one\+pro WON\+pro*\pn*, verse \f + \fr 1:1: \ft This is a footnote for v1.\f*one.
 \li1
 \v 2 \bd C\bd*hapter one,
-\li2 verse\f + \fr 1:2: \ft This is a footnote.\f* two.
+\li2 verse\f + \fr 1:2: \ft This is a footnote for v2.\f* two.
 \v 3 Chapter one \w*,
 \li2 verse three.
-\v 4 Chapter one, 
+\v 4 Chapter one,
 \li2 verse four,
 \v 5 Chapter one,
 \li2 verse \fig Figure 1|src="image1.png" size="col" ref="1:5"\fig* five.
@@ -27,7 +26,7 @@
 \s1 Chapter \it Two \it*
 \p
 \p
-\v 1 Chapter \add two\add*, verse \f + \fr 2:1: \ft This is a footnote.\f*one.
+\v 1 Chapter \add two\add*, verse \f + \fr 2:1: \ft This is a \bd footnote.\bd*\f*one.
 \v 2-3 Chapter two, // verse \fm ∆\fm*two.
 \esb
 \ms This is a sidebar
@@ -38,9 +37,9 @@
 \p
 \v 6 Chapter two, verse \w six|strong="12345" \w*.
 \p
-\v 6 Bad verse. \x - \xo abc\xt 123\x* and more content.
+\v 6 Bad verse. \x - \xo 2:3-4 \xt Cool Book 3:24 \xta The annotation \x* and more content.
 \p
-\v 5 Chapter two, verse five \rq (MAT 3:1)\rq*.
+\v 5 Chapter two, verse five\rq (MAT 3:1)\rq*.
 \v 7a Chapter two, verse seven A,
 \s Section header \ts-s\*
 \p
@@ -55,6 +54,7 @@
 \v 11-12
 \restore restore information
 \c 3
+\r (Mark 1:2-3; Luke 4:5-6)
 \cl PSALM 3
 \s1 Section 1
 \mt1 Major Title 1

--- a/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
+++ b/tests/SIL.Machine.Tests/Corpora/TestData/usfm/Tes/41MATTes.SFM
@@ -1,13 +1,13 @@
 \id MAT - Test
 \h Matthew
 \mt Matthew
-\ip An introduction to Matthew with an empty comment\fe + \ft \fe*
+\ip An introduction to Matthew\fe + \ft This is an endnote.\fe*
 \p \rq MAT 1\rq* Here is another paragraph.
 \p and with a \w keyword|a special concept\w* in it.
 \p and a \weirdtaglookingthing that is not an actual tag.
 \c 1
 \s Chapter One
-\v 1 Chapter \pn one\+pro WON\+pro*\pn*, verse \f + \fr 1:1: \ft This is a footnote for v1.\f*one.
+\v 1 Chapter \pn one\+pro WON\+pro*\pn*, verse one.\f + \fr 1:1: \ft This is a footnote for v1.\f*
 \li1
 \v 2 \bd C\bd*hapter one,
 \li2 verse\f + \fr 1:2: \ft This is a footnote for v2.\f* two.
@@ -26,7 +26,7 @@
 \s1 Chapter \it Two \it*
 \p
 \p
-\v 1 Chapter \add two\add*, verse \f + \fr 2:1: \ft This is a \bd footnote.\bd*\f*one.
+\v 1 Chapter \add two\add*, verse \f + \fr 2:1: \ft This is a footnote.\f*one.
 \v 2-3 Chapter two, // verse \fm ∆\fm*two.
 \esb
 \ms This is a sidebar
@@ -37,9 +37,9 @@
 \p
 \v 6 Chapter two, verse \w six|strong="12345" \w*.
 \p
-\v 6 Bad verse. \x - \xo 2:3-4 \xt Cool Book 3:24 \xta The annotation \x* and more content.
+\v 6 Bad verse. \x - \xo abc\xt 123\x* and more content.
 \p
-\v 5 Chapter two, verse five\rq (MAT 3:1)\rq*.
+\v 5 Chapter two, verse five \rq (MAT 3:1)\rq*.
 \v 7a Chapter two, verse seven A,
 \s Section header \ts-s\*
 \p
@@ -54,7 +54,6 @@
 \v 11-12
 \restore restore information
 \c 3
-\r (Mark 1:2-3; Luke 4:5-6)
 \cl PSALM 3
 \s1 Section 1
 \mt1 Major Title 1

--- a/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
@@ -726,11 +726,11 @@ public class UpdateUsfmParserHandlerTests
     private static void Assess(string target, string truth)
     {
         Assert.That(target, Is.Not.Null);
-        var target_lines = target.Split(new[] { "\r\n" }, StringSplitOptions.None);
+        var target_lines = target.Split(new[] { "\n" }, StringSplitOptions.None);
         var truth_lines = truth.Split(new[] { "\n" }, StringSplitOptions.None);
         for (int i = 0; i < truth_lines.Length; i++)
         {
-            Assert.That(target_lines[i], Is.EqualTo(truth_lines[i]));
+            Assert.That(target_lines[i].Trim(), Is.EqualTo(truth_lines[i].Trim()));
         }
     }
 }

--- a/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
@@ -15,7 +15,12 @@ public class UpdateUsfmParserHandlerTests
 
         string target = UpdateUsfm(rows);
         Assert.That(target, Contains.Substring("\\id MAT - Test\r\n"));
-        Assert.That(target, Contains.Substring("\\v 1 First verse of the first chapter.\r\n"));
+        Assert.That(
+            target,
+            Contains.Substring(
+                "\\v 1 First verse of the first chapter. \\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*\r\n\\li1\r\n\\v 2"
+            )
+        );
     }
 
     [Test]
@@ -28,7 +33,7 @@ public class UpdateUsfmParserHandlerTests
     [Test]
     public void GetUsfm_StripAllText()
     {
-        string target = UpdateUsfm(behavior: UpdateUsfmBehavior.StripExisting);
+        string target = UpdateUsfm(textBehavior: UpdateUsfmTextBehavior.StripExisting);
         Assert.That(target, Contains.Substring("\\id MAT\r\n"));
         Assert.That(target, Contains.Substring("\\v 1\r\n"));
         Assert.That(target, Contains.Substring("\\s\r\n"));
@@ -43,7 +48,7 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 1:6"), "Text 6"),
             (ScrRef("MAT 1:7"), "Text 7"),
         };
-        string target = UpdateUsfm(rows, behavior: UpdateUsfmBehavior.PreferExisting);
+        string target = UpdateUsfm(rows, textBehavior: UpdateUsfmTextBehavior.PreferExisting);
         Assert.That(target, Contains.Substring("\\id MAT - Test\r\n"));
         Assert.That(target, Contains.Substring("\\v 6 Verse 6 content.\r\n"));
         Assert.That(target, Contains.Substring("\\v 7 Text 7\r\n"));
@@ -57,26 +62,43 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 1:6"), "Text 6"),
             (ScrRef("MAT 1:7"), "Text 7"),
         };
-        string target = UpdateUsfm(rows, behavior: UpdateUsfmBehavior.PreferNew);
+        string target = UpdateUsfm(rows, textBehavior: UpdateUsfmTextBehavior.PreferNew);
         Assert.That(target, Contains.Substring("\\id MAT - Test\r\n"));
         Assert.That(target, Contains.Substring("\\v 6 Text 6\r\n"));
         Assert.That(target, Contains.Substring("\\v 7 Text 7\r\n"));
     }
 
     [Test]
-    public void GetUsfm_Verse_SkipNote()
+    public void GetUsfm_Verse_StripNote()
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
         {
             (ScrRef("MAT 2:1"), "First verse of the second chapter.")
         };
 
-        string target = UpdateUsfm(rows);
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
         Assert.That(target, Contains.Substring("\\v 1 First verse of the second chapter.\r\n"));
     }
 
     [Test]
-    public void GetUsfm_Verse_ReplaceNote()
+    public void GetUsfm_Verse_StripNotesWithUpdatedVerseText()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:1"), "First verse of the first chapter.")
+        };
+
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        Assert.That(target, Contains.Substring("\\id MAT - Test\r\n"));
+        Assert.That(
+            target,
+            Contains.Substring("\\ip An introduction to Matthew with an empty comment\\fe + \\ft \\fe*")
+        );
+        Assert.That(target, Contains.Substring("\\v 1 First verse of the first chapter.\r\n\\li1\r\n\\v 2"));
+    }
+
+    [Test]
+    public void GetUsfm_Verse_ReplaceNoteKeepReference()
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
         {
@@ -87,7 +109,45 @@ public class UpdateUsfmParserHandlerTests
         string target = UpdateUsfm(rows);
         Assert.That(
             target,
-            Contains.Substring("\\v 1 First verse of the second chapter. \\f + \\ft This is a new footnote.\\f*\r\n")
+            Contains.Substring(
+                "\\v 1 First verse of the second chapter. \\f + \\fr 2:1: \\ft This is a new footnote. \\f*\r\n"
+            )
+        );
+    }
+
+    [Test]
+    public void GetUsfm_Verse_PreserveFiguresAndReferences()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            // fig
+            (ScrRef("MAT 1:5"), "Fifth verse of the first chapter."),
+            (ScrRef("MAT 1:5/1:fig"), "figure text not updated"),
+            // r
+            (ScrRef("MAT 2:0/1:r"), "parallel reference not updated"),
+            // rq
+            (ScrRef("MAT 2:5/1:rq"), "quote reference not updated"),
+            // xo
+            (ScrRef("MAT 2:6/3:xo"), "Cross reference not update"),
+            // xt
+            (ScrRef("MAT 2:6/4:xt"), "cross reference - target reference not updated"),
+            // xta
+            (ScrRef("MAT 2:6/5:xta"), "cross reference annotation updated"),
+        };
+
+        string target = UpdateUsfm(rows);
+        Assert.That(
+            target,
+            Contains.Substring(
+                "\\v 5 Fifth verse of the first chapter.\r\n\\li2 \\fig Figure 1|src=\"image1.png\" size=\"col\" ref=\"1:5\"\\fig*\r\n\\v 6"
+            )
+        );
+        Assert.That(target, Contains.Substring("\\r (Mark 1:2-3; Luke 4:5-6)\r\n"));
+        Assert.That(
+            target,
+            Contains.Substring(
+                "\\v 6 Bad verse. \\x - \\xo 2:3-4 \\xt Cool Book 3:24 \\xta The annotation \\x* and more content.\r\n"
+            )
         );
     }
 
@@ -100,7 +160,12 @@ public class UpdateUsfmParserHandlerTests
         };
 
         string target = UpdateUsfm(rows);
-        Assert.That(target, Contains.Substring("\\v 1 First verse of the second chapter.\r\n"));
+        Assert.That(
+            target,
+            Contains.Substring(
+                "\\v 1 First verse of the second chapter. \\f + \\fr 2:1: \\ft This is a \\bd footnote.\\bd*\\f*\r\n"
+            )
+        );
     }
 
     [Test]
@@ -124,7 +189,12 @@ public class UpdateUsfmParserHandlerTests
         };
 
         string target = UpdateUsfm(rows);
-        Assert.That(target, Contains.Substring("\\v 2 Second verse of the first chapter.\r\n\\li2\r\n"));
+        Assert.That(
+            target,
+            Contains.Substring(
+                "\\v 2 Second verse of the first chapter.\r\n\\li2 \\f + \\fr 1:2: \\ft This is a footnote for v2.\\f*"
+            )
+        );
     }
 
     [Test]
@@ -200,7 +270,7 @@ public class UpdateUsfmParserHandlerTests
         };
 
         string target = UpdateUsfm(rows);
-        Assert.That(target, Contains.Substring("\\v 2-3 Verse 2. Verse 2a. Verse 2b.\r\n"));
+        Assert.That(target, Contains.Substring("\\v 2-3 Verse 2. Verse 2a. Verse 2b. \\fm ∆\\fm*\r\n"));
     }
 
     [Test]
@@ -212,7 +282,7 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 2:3"), "Third verse of the second chapter.")
         };
 
-        string target = UpdateUsfm(rows);
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
         Assert.That(
             target,
             Contains.Substring("\\v 2-3 Second verse of the second chapter. Third verse of the second chapter.\r\n")
@@ -278,7 +348,12 @@ public class UpdateUsfmParserHandlerTests
 
         string target = UpdateUsfm(rows);
         Assert.That(target, Contains.Substring("\\s The first chapter.\r\n"));
-        Assert.That(target, Contains.Substring("\\v 1 First verse of the first chapter.\r\n"));
+        Assert.That(
+            target,
+            Contains.Substring(
+                "\\v 1 First verse of the first chapter. \\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*\r\n"
+            )
+        );
         Assert.That(
             target,
             Contains.Substring("\\tr \\tc1 The first cell of the table. \\tc2 The second cell of the table.\r\n")
@@ -294,7 +369,7 @@ public class UpdateUsfmParserHandlerTests
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
         {
-            (ScrRef("MAT 2:3/1:esb/1:ms"), "The first paragraph of the sidebar.")
+            (ScrRef("MAT 2:3/2:esb/1:ms"), "The first paragraph of the sidebar.")
         };
 
         string target = UpdateUsfm(rows);
@@ -326,7 +401,7 @@ public class UpdateUsfmParserHandlerTests
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
         {
-            (ScrRef("MAT 2:3/1:esb/2:p"), "The second paragraph of the sidebar.")
+            (ScrRef("MAT 2:3/2:esb/2:p"), "The second paragraph of the sidebar.")
         };
 
         string target = UpdateUsfm(rows);
@@ -346,6 +421,18 @@ public class UpdateUsfmParserHandlerTests
     }
 
     [Test]
+    public void GetUsfm_NonVerse_KeepNote()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:0/3:ip"), "The introductory paragraph.")
+        };
+
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Preserve);
+        Assert.That(target, Contains.Substring("\\ip The introductory paragraph. \\fe + \\ft \\fe*\r\n"));
+    }
+
+    [Test]
     public void GetUsfm_NonVerse_SkipNote()
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
@@ -353,7 +440,7 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 1:0/3:ip"), "The introductory paragraph.")
         };
 
-        string target = UpdateUsfm(rows);
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
         Assert.That(target, Contains.Substring("\\ip The introductory paragraph.\r\n"));
     }
 
@@ -369,7 +456,7 @@ public class UpdateUsfmParserHandlerTests
         string target = UpdateUsfm(rows);
         Assert.That(
             target,
-            Contains.Substring("\\ip The introductory paragraph. \\fe + \\ft This is a new endnote.\\fe*\r\n")
+            Contains.Substring("\\ip The introductory paragraph. \\fe + \\ft This is a new endnote. \\fe*\r\n")
         );
     }
 
@@ -426,7 +513,7 @@ public class UpdateUsfmParserHandlerTests
         };
 
         string target = UpdateUsfm(rows);
-        Assert.That(target, Contains.Substring("\\ip The introductory paragraph.\r\n"));
+        Assert.That(target, Contains.Substring("\\ip The introductory paragraph. \\fe + \\ft \\fe*\r\n"));
     }
 
     private static ScriptureRef[] ScrRef(params string[] refs)
@@ -438,18 +525,20 @@ public class UpdateUsfmParserHandlerTests
         IReadOnlyList<(IReadOnlyList<ScriptureRef>, string)>? rows = null,
         string? source = null,
         string? idText = null,
-        UpdateUsfmBehavior behavior = UpdateUsfmBehavior.PreferNew
+        UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferNew,
+        UpdateUsfmIntraVerseMarkerBehavior embedBehavior = UpdateUsfmIntraVerseMarkerBehavior.Preserve,
+        UpdateUsfmIntraVerseMarkerBehavior styleBehavior = UpdateUsfmIntraVerseMarkerBehavior.Strip
     )
     {
         if (source is null)
         {
             var updater = new FileParatextProjectTextUpdater(CorporaTestHelpers.UsfmTestProjectPath);
-            return updater.UpdateUsfm("MAT", rows, idText, behavior);
+            return updater.UpdateUsfm("MAT", rows, idText, textBehavior, embedBehavior, styleBehavior);
         }
         else
         {
             source = source.Trim().ReplaceLineEndings("\r\n") + "\r\n";
-            var updater = new UpdateUsfmParserHandler(rows, idText, behavior);
+            var updater = new UpdateUsfmParserHandler(rows, idText, textBehavior, embedBehavior, styleBehavior);
             UsfmParser.Parse(source, updater);
             return updater.GetUsfm();
         }

--- a/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
@@ -88,7 +88,7 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 2:1"), "First verse of the second chapter.")
         };
 
-        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
         Assert.That(target, Contains.Substring("\\v 1 First verse of the second chapter.\r\n"));
     }
 
@@ -245,7 +245,7 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 2:3"), "Third verse of the second chapter.")
         };
 
-        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
         Assert.That(
             target,
             Contains.Substring("\\v 2-3 Second verse of the second chapter. Third verse of the second chapter.\r\n")
@@ -391,7 +391,7 @@ public class UpdateUsfmParserHandlerTests
             (ScrRef("MAT 1:0/3:ip"), "The introductory paragraph.")
         };
 
-        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        string target = UpdateUsfm(rows, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
         Assert.That(target, Contains.Substring("\\ip The introductory paragraph.\r\n"));
     }
 
@@ -490,8 +490,8 @@ public class UpdateUsfmParserHandlerTests
         var target = UpdateUsfm(
             rows,
             usfm,
-            embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Preserve,
-            styleBehavior: UpdateUsfmIntraVerseMarkerBehavior.Preserve
+            embedBehavior: UpdateUsfmMarkerBehavior.Preserve,
+            styleBehavior: UpdateUsfmMarkerBehavior.Preserve
         );
         var resultPp =
             @"\id MAT - Test
@@ -505,8 +505,8 @@ public class UpdateUsfmParserHandlerTests
         target = UpdateUsfm(
             rows,
             usfm,
-            embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Preserve,
-            styleBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip
+            embedBehavior: UpdateUsfmMarkerBehavior.Preserve,
+            styleBehavior: UpdateUsfmMarkerBehavior.Strip
         );
         var resultPs =
             @"\id MAT - Test
@@ -520,8 +520,8 @@ public class UpdateUsfmParserHandlerTests
         target = UpdateUsfm(
             rows,
             usfm,
-            embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip,
-            styleBehavior: UpdateUsfmIntraVerseMarkerBehavior.Preserve
+            embedBehavior: UpdateUsfmMarkerBehavior.Strip,
+            styleBehavior: UpdateUsfmMarkerBehavior.Preserve
         );
         var resultSp =
             @"\id MAT - Test
@@ -535,8 +535,8 @@ public class UpdateUsfmParserHandlerTests
         target = UpdateUsfm(
             rows,
             usfm,
-            embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip,
-            styleBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip
+            embedBehavior: UpdateUsfmMarkerBehavior.Strip,
+            styleBehavior: UpdateUsfmMarkerBehavior.Strip
         );
         var resultSs =
             @"\id MAT - Test
@@ -626,7 +626,7 @@ public class UpdateUsfmParserHandlerTests
 ";
         Assess(target, result);
 
-        target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
         var result2 =
             @"\id MAT - Test
 \c 1
@@ -656,7 +656,7 @@ public class UpdateUsfmParserHandlerTests
 ";
         Assess(target, result);
 
-        target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
         var result2 =
             @"\id MAT - Test
 \c 1
@@ -686,7 +686,7 @@ public class UpdateUsfmParserHandlerTests
 ";
         Assess(target, result);
 
-        target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmIntraVerseMarkerBehavior.Strip);
+        target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
         var result2 =
             @"\id MAT - Test
 \c 1
@@ -705,8 +705,8 @@ public class UpdateUsfmParserHandlerTests
         string? source = null,
         string? idText = null,
         UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferNew,
-        UpdateUsfmIntraVerseMarkerBehavior embedBehavior = UpdateUsfmIntraVerseMarkerBehavior.Preserve,
-        UpdateUsfmIntraVerseMarkerBehavior styleBehavior = UpdateUsfmIntraVerseMarkerBehavior.Strip
+        UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
+        UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip
     )
     {
         if (source is null)

--- a/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
@@ -149,7 +149,7 @@ public class UsfmFileTextTests
         Assert.That(rows, Has.Length.EqualTo(24));
 
         Assert.That(rows[3].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:4", corpus.Versification)));
-        Assert.That(rows[3].Text, Is.EqualTo("Chapter one, verse four,"));
+        Assert.That(rows[3].Text, Is.EqualTo("Chapter one with odd whitespace, verse four,"));
         Assert.That(rows[3].IsSentenceStart, Is.True);
 
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:5", corpus.Versification)));

--- a/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
@@ -73,7 +73,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(50));
+        Assert.That(rows, Has.Length.EqualTo(51));
 
         Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/1:h", corpus.Versification)));
         Assert.That(rows[0].Text, Is.EqualTo("Matthew"));
@@ -82,10 +82,10 @@ public class UsfmFileTextTests
         Assert.That(rows[1].Text, Is.EqualTo("Matthew"));
 
         Assert.That(rows[2].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip", corpus.Versification)));
-        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew"));
+        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew with an empty comment"));
 
         Assert.That(rows[3].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip/1:fe", corpus.Versification)));
-        Assert.That(rows[3].Text, Is.EqualTo("This is an endnote."));
+        Assert.That(rows[3].Text, Is.EqualTo(""));
 
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/4:p", corpus.Versification)));
         Assert.That(rows[4].Text, Is.EqualTo("MAT 1 Here is another paragraph."));
@@ -100,10 +100,10 @@ public class UsfmFileTextTests
         Assert.That(rows[8].Text, Is.EqualTo("Chapter One"));
 
         Assert.That(rows[10].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:1/1:f", corpus.Versification)));
-        Assert.That(rows[10].Text, Is.EqualTo("1:1: This is a footnote."));
+        Assert.That(rows[10].Text, Is.EqualTo("This is a footnote for v1."));
 
         Assert.That(rows[12].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:2/1:f", corpus.Versification)));
-        Assert.That(rows[12].Text, Is.EqualTo("1:2: This is a footnote."));
+        Assert.That(rows[12].Text, Is.EqualTo("This is a footnote for v2."));
 
         Assert.That(rows[19].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:0/1:tr/1:tc1", corpus.Versification)));
         Assert.That(rows[19].Text, Is.EqualTo("Row one, column one."));
@@ -124,12 +124,12 @@ public class UsfmFileTextTests
         Assert.That(rows[24].Text, Is.Empty);
 
         Assert.That(rows[26].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1/1:f", corpus.Versification)));
-        Assert.That(rows[26].Text, Is.EqualTo("2:1: This is a footnote."));
+        Assert.That(rows[26].Text, Is.EqualTo("This is a footnote."));
 
-        Assert.That(rows[29].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/1:ms", corpus.Versification)));
+        Assert.That(rows[29].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/2:esb/1:ms", corpus.Versification)));
         Assert.That(rows[29].Text, Is.EqualTo("This is a sidebar"));
 
-        Assert.That(rows[30].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/2:p", corpus.Versification)));
+        Assert.That(rows[30].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/2:esb/2:p", corpus.Versification)));
         Assert.That(rows[30].Text, Is.EqualTo("Here is some sidebar content."));
 
         Assert.That(rows[36].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:7a/1:s", corpus.Versification)));
@@ -149,7 +149,7 @@ public class UsfmFileTextTests
         Assert.That(rows, Has.Length.EqualTo(24));
 
         Assert.That(rows[3].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:4", corpus.Versification)));
-        Assert.That(rows[3].Text, Is.EqualTo("Chapter one, verse four,"));
+        Assert.That(rows[3].Text, Is.EqualTo("Chapter one, verse four,"));
         Assert.That(rows[3].IsSentenceStart, Is.True);
 
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:5", corpus.Versification)));
@@ -184,13 +184,15 @@ public class UsfmFileTextTests
         Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:1", corpus.Versification)));
         Assert.That(
             rows[0].Text,
-            Is.EqualTo("Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote.\\f*")
+            Is.EqualTo(
+                "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse \\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*one."
+            )
         );
 
         Assert.That(rows[1].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:2", corpus.Versification)));
         Assert.That(
             rows[1].Text,
-            Is.EqualTo("\\bd C\\bd*hapter one, \\li2 verse\\f + \\fr 1:2: \\ft This is a footnote.\\f* two.")
+            Is.EqualTo("\\bd C\\bd*hapter one, \\li2 verse\\f + \\fr 1:2: \\ft This is a footnote for v2.\\f* two.")
         );
 
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:5", corpus.Versification)));
@@ -204,7 +206,7 @@ public class UsfmFileTextTests
         Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
         Assert.That(
             rows[8].Text,
-            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a footnote.\\f*one.")
+            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a \\bd footnote.\\bd*\\f*one.")
         );
 
         Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:2", corpus.Versification)));
@@ -229,7 +231,7 @@ public class UsfmFileTextTests
         Assert.That(rows[12].Text, Is.EqualTo("Chapter two, verse four."));
 
         Assert.That(rows[13].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:5", corpus.Versification)));
-        Assert.That(rows[13].Text, Is.EqualTo("Chapter two, verse five \\rq (MAT 3:1)\\rq*."));
+        Assert.That(rows[13].Text, Is.EqualTo("Chapter two, verse five\\rq (MAT 3:1)\\rq*."));
 
         Assert.That(rows[14].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:6", corpus.Versification)));
         Assert.That(rows[14].Text, Is.EqualTo("Chapter two, verse \\w six|strong=\"12345\" \\w*."));
@@ -254,21 +256,23 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(46));
+        Assert.That(rows, Has.Length.EqualTo(47));
 
         Assert.That(rows[2].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip", corpus.Versification)));
-        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew\\fe + \\ft This is an endnote.\\fe*"));
+        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew with an empty comment\\fe + \\ft \\fe*"));
 
         Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:1", corpus.Versification)));
         Assert.That(
             rows[8].Text,
-            Is.EqualTo("Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote.\\f*")
+            Is.EqualTo(
+                "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse \\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*one."
+            )
         );
 
         Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:2", corpus.Versification)));
         Assert.That(
             rows[9].Text,
-            Is.EqualTo("\\bd C\\bd*hapter one, \\li2 verse\\f + \\fr 1:2: \\ft This is a footnote.\\f* two.")
+            Is.EqualTo("\\bd C\\bd*hapter one, \\li2 verse\\f + \\fr 1:2: \\ft This is a footnote for v2.\\f* two.")
         );
 
         Assert.That(rows[12].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:5", corpus.Versification)));
@@ -285,10 +289,10 @@ public class UsfmFileTextTests
         Assert.That(rows[22].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
         Assert.That(
             rows[22].Text,
-            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a footnote.\\f*one.")
+            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a \\bd footnote.\\bd*\\f*one.")
         );
 
-        Assert.That(rows[26].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/1:esb/2:p", corpus.Versification)));
+        Assert.That(rows[26].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/2:esb/2:p", corpus.Versification)));
         Assert.That(rows[26].Text, Is.EqualTo("Here is some sidebar // content."));
     }
 }

--- a/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmFileTextTests.cs
@@ -73,7 +73,7 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(51));
+        Assert.That(rows, Has.Length.EqualTo(50));
 
         Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/1:h", corpus.Versification)));
         Assert.That(rows[0].Text, Is.EqualTo("Matthew"));
@@ -82,10 +82,10 @@ public class UsfmFileTextTests
         Assert.That(rows[1].Text, Is.EqualTo("Matthew"));
 
         Assert.That(rows[2].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip", corpus.Versification)));
-        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew with an empty comment"));
+        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew"));
 
         Assert.That(rows[3].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip/1:fe", corpus.Versification)));
-        Assert.That(rows[3].Text, Is.EqualTo(""));
+        Assert.That(rows[3].Text, Is.EqualTo("This is an endnote."));
 
         Assert.That(rows[4].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/4:p", corpus.Versification)));
         Assert.That(rows[4].Text, Is.EqualTo("MAT 1 Here is another paragraph."));
@@ -185,7 +185,7 @@ public class UsfmFileTextTests
         Assert.That(
             rows[0].Text,
             Is.EqualTo(
-                "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse \\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*one."
+                "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*"
             )
         );
 
@@ -206,7 +206,7 @@ public class UsfmFileTextTests
         Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
         Assert.That(
             rows[8].Text,
-            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a \\bd footnote.\\bd*\\f*one.")
+            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a footnote.\\f*one.")
         );
 
         Assert.That(rows[9].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:2", corpus.Versification)));
@@ -231,7 +231,7 @@ public class UsfmFileTextTests
         Assert.That(rows[12].Text, Is.EqualTo("Chapter two, verse four."));
 
         Assert.That(rows[13].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:5", corpus.Versification)));
-        Assert.That(rows[13].Text, Is.EqualTo("Chapter two, verse five\\rq (MAT 3:1)\\rq*."));
+        Assert.That(rows[13].Text, Is.EqualTo("Chapter two, verse five \\rq (MAT 3:1)\\rq*."));
 
         Assert.That(rows[14].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:6", corpus.Versification)));
         Assert.That(rows[14].Text, Is.EqualTo("Chapter two, verse \\w six|strong=\"12345\" \\w*."));
@@ -256,16 +256,16 @@ public class UsfmFileTextTests
 
         IText text = corpus["MAT"];
         TextRow[] rows = text.GetRows().ToArray();
-        Assert.That(rows, Has.Length.EqualTo(47));
+        Assert.That(rows, Has.Length.EqualTo(46));
 
         Assert.That(rows[2].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/3:ip", corpus.Versification)));
-        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew with an empty comment\\fe + \\ft \\fe*"));
+        Assert.That(rows[2].Text, Is.EqualTo("An introduction to Matthew\\fe + \\ft This is an endnote.\\fe*"));
 
         Assert.That(rows[8].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:1", corpus.Versification)));
         Assert.That(
             rows[8].Text,
             Is.EqualTo(
-                "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse \\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*one."
+                "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*"
             )
         );
 
@@ -289,7 +289,7 @@ public class UsfmFileTextTests
         Assert.That(rows[22].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:1", corpus.Versification)));
         Assert.That(
             rows[22].Text,
-            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a \\bd footnote.\\bd*\\f*one.")
+            Is.EqualTo("Chapter \\add two\\add*, verse \\f + \\fr 2:1: \\ft This is a footnote.\\f*one.")
         );
 
         Assert.That(rows[26].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 2:3/2:esb/2:p", corpus.Versification)));

--- a/tests/SIL.Machine.Tests/Corpora/UsfmManualTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmManualTests.cs
@@ -49,7 +49,11 @@ public class UsfmManualTests
             string bookId;
             if (!targetSettings.IsBookFileName(sfmFileName, out bookId))
                 continue;
-            string newUsfm = updater.UpdateUsfm(bookId, pretranslations, behavior: UpdateUsfmBehavior.StripExisting);
+            string newUsfm = updater.UpdateUsfm(
+                bookId,
+                pretranslations,
+                textBehavior: UpdateUsfmTextBehavior.StripExisting
+            );
             Assert.That(newUsfm, Is.Not.Null);
         }
     }
@@ -150,7 +154,7 @@ public class UsfmManualTests
                 string newUsfm = updater.UpdateUsfm(
                     bookId,
                     pretranslations,
-                    behavior: UpdateUsfmBehavior.StripExisting
+                    textBehavior: UpdateUsfmTextBehavior.StripExisting
                 );
                 Assert.That(newUsfm, Is.Not.Null);
             }

--- a/tests/SIL.Machine.Tests/Corpora/UsfmMemoryTextTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmMemoryTextTests.cs
@@ -148,7 +148,32 @@ description
             includeAllText: true
         );
 
-        Assert.That(rows, Has.Length.EqualTo(4), string.Join(",", rows.Select(tr => tr.Text)));
+        Assert.That(rows, Has.Length.EqualTo(5), string.Join(",", rows.Select(tr => tr.Text)));
+        Assert.That(rows[0].Text, Is.EqualTo(""));
+        Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/1:q1")));
+        Assert.That(rows[1].Text, Is.EqualTo("World"));
+        Assert.That(rows[1].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/1:q1/1:f")));
+    }
+
+    [Test]
+    public void GetRows_VersePara_CommentFirst()
+    {
+        TextRow[] rows = GetRows(
+            @"\id MAT - Test
+\f \fr 119 \ft World \f*
+\ip This is a comment
+\c 1
+\v 1 First verse in line!?!
+\c 2
+",
+            includeAllText: true
+        );
+
+        Assert.That(rows[0].Text, Is.EqualTo("World"));
+        Assert.That(rows[0].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/1:f")));
+        Assert.That(rows[1].Text, Is.EqualTo("This is a comment"));
+        Assert.That(rows[1].Ref, Is.EqualTo(ScriptureRef.Parse("MAT 1:0/2:ip")));
+        Assert.That(rows, Has.Length.EqualTo(3), string.Join(",", rows.Select(tr => tr.Text)));
     }
 
     [Test]

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
@@ -19,22 +19,22 @@ public class UsfmTokenizerTests
         Assert.That(tokens[0].LineNumber, Is.EqualTo(1));
         Assert.That(tokens[0].ColumnNumber, Is.EqualTo(1));
 
-        Assert.That(tokens[37].Type, Is.EqualTo(UsfmTokenType.Text));
-        Assert.That(tokens[37].Text, Is.EqualTo("Chapter One "));
-        Assert.That(tokens[37].LineNumber, Is.EqualTo(10));
-        Assert.That(tokens[37].ColumnNumber, Is.EqualTo(4));
+        Assert.That(tokens[30].Type, Is.EqualTo(UsfmTokenType.Text));
+        Assert.That(tokens[30].Text, Is.EqualTo("Chapter One "));
+        Assert.That(tokens[30].LineNumber, Is.EqualTo(9));
+        Assert.That(tokens[30].ColumnNumber, Is.EqualTo(4));
 
-        Assert.That(tokens[38].Type, Is.EqualTo(UsfmTokenType.Verse));
-        Assert.That(tokens[38].Marker, Is.EqualTo("v"));
-        Assert.That(tokens[38].Data, Is.EqualTo("1"));
-        Assert.That(tokens[38].LineNumber, Is.EqualTo(11));
-        Assert.That(tokens[38].ColumnNumber, Is.EqualTo(1));
+        Assert.That(tokens[31].Type, Is.EqualTo(UsfmTokenType.Verse));
+        Assert.That(tokens[31].Marker, Is.EqualTo("v"));
+        Assert.That(tokens[31].Data, Is.EqualTo("1"));
+        Assert.That(tokens[31].LineNumber, Is.EqualTo(10));
+        Assert.That(tokens[31].ColumnNumber, Is.EqualTo(1));
 
-        Assert.That(tokens[47].Type, Is.EqualTo(UsfmTokenType.Note));
-        Assert.That(tokens[47].Marker, Is.EqualTo("f"));
-        Assert.That(tokens[47].Data, Is.EqualTo("+"));
-        Assert.That(tokens[47].LineNumber, Is.EqualTo(11));
-        Assert.That(tokens[47].ColumnNumber, Is.EqualTo(52));
+        Assert.That(tokens[40].Type, Is.EqualTo(UsfmTokenType.Note));
+        Assert.That(tokens[40].Marker, Is.EqualTo("f"));
+        Assert.That(tokens[40].Data, Is.EqualTo("+"));
+        Assert.That(tokens[40].LineNumber, Is.EqualTo(10));
+        Assert.That(tokens[40].ColumnNumber, Is.EqualTo(48));
     }
 
     [Test]

--- a/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UsfmTokenizerTests.cs
@@ -11,7 +11,7 @@ public class UsfmTokenizerTests
         string usfm = ReadUsfm();
         var tokenizer = new UsfmTokenizer();
         IReadOnlyList<UsfmToken> tokens = tokenizer.Tokenize(usfm);
-        Assert.That(tokens, Has.Count.EqualTo(236));
+        Assert.That(tokens, Has.Count.EqualTo(230));
 
         Assert.That(tokens[0].Type, Is.EqualTo(UsfmTokenType.Book));
         Assert.That(tokens[0].Marker, Is.EqualTo("id"));
@@ -19,22 +19,22 @@ public class UsfmTokenizerTests
         Assert.That(tokens[0].LineNumber, Is.EqualTo(1));
         Assert.That(tokens[0].ColumnNumber, Is.EqualTo(1));
 
-        Assert.That(tokens[30].Type, Is.EqualTo(UsfmTokenType.Text));
-        Assert.That(tokens[30].Text, Is.EqualTo("Chapter One "));
-        Assert.That(tokens[30].LineNumber, Is.EqualTo(9));
-        Assert.That(tokens[30].ColumnNumber, Is.EqualTo(4));
+        Assert.That(tokens[31].Type, Is.EqualTo(UsfmTokenType.Text));
+        Assert.That(tokens[31].Text, Is.EqualTo("Chapter One "));
+        Assert.That(tokens[31].LineNumber, Is.EqualTo(9));
+        Assert.That(tokens[31].ColumnNumber, Is.EqualTo(4));
 
-        Assert.That(tokens[31].Type, Is.EqualTo(UsfmTokenType.Verse));
-        Assert.That(tokens[31].Marker, Is.EqualTo("v"));
-        Assert.That(tokens[31].Data, Is.EqualTo("1"));
-        Assert.That(tokens[31].LineNumber, Is.EqualTo(10));
-        Assert.That(tokens[31].ColumnNumber, Is.EqualTo(1));
+        Assert.That(tokens[32].Type, Is.EqualTo(UsfmTokenType.Verse));
+        Assert.That(tokens[32].Marker, Is.EqualTo("v"));
+        Assert.That(tokens[32].Data, Is.EqualTo("1"));
+        Assert.That(tokens[32].LineNumber, Is.EqualTo(10));
+        Assert.That(tokens[32].ColumnNumber, Is.EqualTo(1));
 
-        Assert.That(tokens[40].Type, Is.EqualTo(UsfmTokenType.Note));
-        Assert.That(tokens[40].Marker, Is.EqualTo("f"));
-        Assert.That(tokens[40].Data, Is.EqualTo("+"));
-        Assert.That(tokens[40].LineNumber, Is.EqualTo(10));
-        Assert.That(tokens[40].ColumnNumber, Is.EqualTo(48));
+        Assert.That(tokens[41].Type, Is.EqualTo(UsfmTokenType.Note));
+        Assert.That(tokens[41].Marker, Is.EqualTo("f"));
+        Assert.That(tokens[41].Data, Is.EqualTo("+"));
+        Assert.That(tokens[41].LineNumber, Is.EqualTo(10));
+        Assert.That(tokens[41].ColumnNumber, Is.EqualTo(52));
     }
 
     [Test]


### PR DESCRIPTION
This attempts to address the following issues:
* https://github.com/sillsdev/serval/issues/577
* https://github.com/sillsdev/serval/issues/574

It also reworks the Note handling, making it so that it preserves the reference fields.
It also combines Notes, Figures and Cross References as "SubComponents"

There are still a few tests that need fixed.

There are significant parsing updates - and the tests were updated to match the updated behavior.  @ddaspit - can you check to see if they are going in the right direction?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/281)
<!-- Reviewable:end -->
