### PR TITLE
Merge duplicate analyses

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -67,6 +67,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_morpher.TraceManager.IsTracing)
                 _morpher.TraceManager.BeginUnapplyStratum(_stratum, input);
 
+            Word origInput = input;
             input = input.Clone();
             input.Stratum = _stratum;
 
@@ -89,11 +90,13 @@ namespace SIL.Machine.Morphology.HermitCrab
             {
                 if (mergeEquivalentAnalyses)
                 {
+                    // Skip intermediate sources from phonological rules, templates, and morphological rules.
+                    mruleOutWord.Source = origInput;
                     Shape shape = mruleOutWord.Shape;
                     if (shapeWord.ContainsKey(shape))
                     {
                         shapeWord[shape].Alternatives.Add(mruleOutWord);
-                         continue;
+                        continue;
                     }
                     shapeWord[shape] = mruleOutWord;
                 }

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -88,10 +88,10 @@ namespace SIL.Machine.Morphology.HermitCrab
                 _morpher.TraceManager.EndUnapplyStratum(_stratum, input);
             foreach (Word mruleOutWord in mruleOutWords)
             {
+                // Skip intermediate sources from phonological rules, templates, and morphological rules.
+                mruleOutWord.Source = origInput;
                 if (mergeEquivalentAnalyses)
                 {
-                    // Skip intermediate sources from phonological rules, templates, and morphological rules.
-                    mruleOutWord.Source = origInput;
                     Shape shape = mruleOutWord.Shape;
                     if (shapeWord.ContainsKey(shape))
                     {

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -93,9 +93,10 @@ namespace SIL.Machine.Morphology.HermitCrab
                 if (mergeEquivalentAnalyses)
                 {
                     Shape shape = mruleOutWord.Shape;
-                    if (shapeWord.ContainsKey(shape))
+                    Word canonicalWord;
+                    if (shapeWord.TryGetValue(shape, out canonicalWord))
                     {
-                        shapeWord[shape].Alternatives.Add(mruleOutWord);
+                        canonicalWord.Alternatives.Add(mruleOutWord);
                         continue;
                     }
                     shapeWord[shape] = mruleOutWord;

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -146,10 +146,13 @@ namespace SIL.Machine.Morphology.HermitCrab
                     var lexicalGuesses = LexicalGuess(analysisWord).Distinct();
                     foreach (Word synthesisWord in lexicalGuesses)
                     {
-                        foreach (Word validWord in _synthesisRule.Apply(synthesisWord).Where(IsWordValid))
+                        foreach (Word alternative in synthesisWord.ExpandAlternatives())
                         {
-                            if (IsMatch(word, validWord))
-                                matches.Add(validWord);
+                            foreach (Word validWord in _synthesisRule.Apply(alternative).Where(IsWordValid))
+                            {
+                                if (IsMatch(word, validWord))
+                                    matches.Add(validWord);
+                            }
                         }
                     }
                 }
@@ -285,10 +288,13 @@ namespace SIL.Machine.Morphology.HermitCrab
             {
                 foreach (Word synthesisWord in LexicalLookup(analysisWord))
                 {
-                    foreach (Word validWord in _synthesisRule.Apply(synthesisWord).Where(IsWordValid))
+                    foreach (Word alternative in synthesisWord.ExpandAlternatives())
                     {
-                        if (IsMatch(word, validWord))
-                            matches.Add(validWord);
+                        foreach (Word validWord in _synthesisRule.Apply(alternative).Where(IsWordValid))
+                        {
+                            if (IsMatch(word, validWord))
+                                matches.Add(validWord);
+                        }
                     }
                 }
             }
@@ -311,9 +317,9 @@ namespace SIL.Machine.Morphology.HermitCrab
                             analyses.TryDequeue(out Word analysisWord);
                             foreach (Word synthesisWord in LexicalLookup(analysisWord))
                             {
-                                foreach (Word alternativeSynthesis in synthesisWord.ExpandAlternatives())
+                                foreach (Word alternative in synthesisWord.ExpandAlternatives())
                                 {
-                                    foreach (Word validWord in _synthesisRule.Apply(alternativeSynthesis).Where(IsWordValid))
+                                    foreach (Word validWord in _synthesisRule.Apply(alternative).Where(IsWordValid))
                                     {
                                         if (IsMatch(word, validWord))
                                             matches.Add(validWord);

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -56,6 +56,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             _synthesisRule = lang.CompileSynthesisRule(this);
             MaxStemCount = 2;
             MaxUnapplications = 0;
+            MergeEquivalentAnalyses = true;
             LexEntrySelector = entry => true;
             RuleSelector = rule => true;
 
@@ -77,6 +78,12 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// because there are too many unapplications.
         /// </summary>
         public int MaxUnapplications { get; set; }
+
+        /// <summary>
+        /// Merge analyses that have equivalent shapes.
+        /// Merged analyses will be expanded if lexical lookup succeeds.
+        /// </summary>
+        public bool MergeEquivalentAnalyses { get; set; }
 
         public Func<LexEntry, bool> LexEntrySelector { get; set; }
         public Func<IHCRule, bool> RuleSelector { get; set; }
@@ -304,10 +311,13 @@ namespace SIL.Machine.Morphology.HermitCrab
                             analyses.TryDequeue(out Word analysisWord);
                             foreach (Word synthesisWord in LexicalLookup(analysisWord))
                             {
-                                foreach (Word validWord in _synthesisRule.Apply(synthesisWord).Where(IsWordValid))
+                                foreach (Word alternativeSynthesis in synthesisWord.ExpandAlternatives())
                                 {
-                                    if (IsMatch(word, validWord))
-                                        matches.Add(validWord);
+                                    foreach (Word validWord in _synthesisRule.Apply(alternativeSynthesis).Where(IsWordValid))
+                                    {
+                                        if (IsMatch(word, validWord))
+                                            matches.Add(validWord);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This merges equivalent analyses in AnalysisStratumRule.Apply and then expands alternatives after they have been found in the lexicon in Morpher.  This can speed things up by 3-4x if there are multiple strata since fewer analyses get passed from one stratum to the next.  It required adding a Source field and an Alternatives field to Word so that the alternatives can be reconstructed by Word.ExpandAlternatives.  The Source field gets filled in with the original word when a Word is cloned so that past alternatives can be accessed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/282)
<!-- Reviewable:end -->
