### PR TITLE
Fix bug with realizational rules

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/Word.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Word.cs
@@ -410,7 +410,7 @@ namespace SIL.Machine.Morphology.HermitCrab
         {
             IList<Word> alternatives = new List<Word>();
             IList<Word> originals = Source?.ExpandAlternatives();
-            // Update the alternatives of CloneOf with any changes made since the clone.
+            // Update the alternatives of Source with any changes made since Source.
             if (originals == null || originals.Count < 2)
             {
                 // Special case.
@@ -429,9 +429,16 @@ namespace SIL.Machine.Morphology.HermitCrab
                     int nh_start = Source == null ? 0 : Source._nonHeadApps.Count();
                     for (int i = nh_start; i < _nonHeadApps.Count(); i++)
                         alternative.NonHeadUnapplied(_nonHeadApps[i]);
-                    if (_realizationalFS != Source._realizationalFS)
-                        alternative._realizationalFS = _realizationalFS;
-                    if (RootAllomorph != null)
+                    // Add changes to feature structures to alternative.
+                    if (!_realizationalFS.ValueEquals(Source._realizationalFS))
+                    {
+                        FeatureStruct diff = _realizationalFS.Clone();
+                        diff.Subtract(Source._realizationalFS);
+                        FeatureStruct newFS;
+                        alternative._realizationalFS.Unify(diff, out newFS);
+                        alternative._realizationalFS = newFS;
+                    }
+                    if (RootAllomorph != Source.RootAllomorph)
                         alternative.RootAllomorph = RootAllomorph;
                     alternative.Freeze();
                     alternatives.Add(alternative);

--- a/src/SIL.Machine.Morphology.HermitCrab/Word.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Word.cs
@@ -429,6 +429,8 @@ namespace SIL.Machine.Morphology.HermitCrab
                     int nh_start = Source == null ? 0 : Source._nonHeadApps.Count();
                     for (int i = nh_start; i < _nonHeadApps.Count(); i++)
                         alternative.NonHeadUnapplied(_nonHeadApps[i]);
+                    if (_realizationalFS != Source._realizationalFS)
+                        alternative._realizationalFS = _realizationalFS;
                     if (RootAllomorph != null)
                         alternative.RootAllomorph = RootAllomorph;
                     alternative.Freeze();


### PR DESCRIPTION
ExpandAlternatives didn't work correctly with realizational rules.  I didn't notice this before because ExpandAlternatives treated originals.Count == 1 as a special case, and bypassed the code for reconstructing the alternative starting at line 423.  Disabling the special case code caused the RealizationRule unit test to fail.  All of the unit tests work now, but if you can think of anything else the code for reconstructing the alternative should include, please let me know.  Ideally, the code for reconstruction would figure out what changes were made between Source and this, and then apply those changes to the alternative. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/285)
<!-- Reviewable:end -->
