### PR TITLE
Updates to USFM updater

### DIFF
--- a/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
+++ b/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Text;
 
@@ -28,7 +27,7 @@ namespace SIL.Machine.Corpora
             UpdateUsfmMarkerBehavior paragraphBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip,
-            ImmutableHashSet<string> preserveParagraphStyles = null
+            IReadOnlyCollection<string> preserveParagraphStyles = null
         )
         {
             string fileName = _settings.GetBookFileName(bookId);

--- a/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
+++ b/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Text;
 
@@ -26,7 +27,8 @@ namespace SIL.Machine.Corpora
             UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferExisting,
             UpdateUsfmMarkerBehavior paragraphBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
-            UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip
+            UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip,
+            ImmutableHashSet<string> preserveParagraphStyles = null
         )
         {
             string fileName = _settings.GetBookFileName(bookId);
@@ -45,7 +47,8 @@ namespace SIL.Machine.Corpora
                 textBehavior,
                 paragraphBehavior,
                 embedBehavior,
-                styleBehavior
+                styleBehavior,
+                preserveParagraphStyles
             );
             try
             {

--- a/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
+++ b/src/SIL.Machine/Corpora/ParatextProjectTextUpdaterBase.cs
@@ -24,6 +24,7 @@ namespace SIL.Machine.Corpora
             IReadOnlyList<(IReadOnlyList<ScriptureRef>, string)> rows,
             string fullName = null,
             UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferExisting,
+            UpdateUsfmMarkerBehavior paragraphBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip
         )
@@ -42,6 +43,7 @@ namespace SIL.Machine.Corpora
                 rows,
                 fullName is null ? null : $"- {fullName}",
                 textBehavior,
+                paragraphBehavior,
                 embedBehavior,
                 styleBehavior
             );

--- a/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
+++ b/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
@@ -10,7 +10,6 @@ namespace SIL.Machine.Corpora
         None,
         NonVerse,
         Verse,
-        Embed,
         NoteText
     }
 
@@ -20,8 +19,6 @@ namespace SIL.Machine.Corpora
         private readonly Stack<ScriptureElement> _curElements;
         private readonly Stack<ScriptureTextType> _curTextType;
         private bool _duplicateVerse = false;
-        private bool _inPreservedParagraph = false;
-
         private bool _inEmbed;
         protected bool InNoteText { get; private set; }
         private bool _inNestedEmbed;
@@ -35,7 +32,6 @@ namespace SIL.Machine.Corpora
         protected ScriptureTextType CurrentTextType =>
             _curTextType.Count == 0 ? ScriptureTextType.None : _curTextType.Peek();
 
-        private static readonly string[] PreserveParagraphStyles = new[] { "r", "rem" };
         private static readonly string[] EmbedStyles = new[] { "f", "fe", "fig", "fm", "x" };
         private static readonly char[] EmbedPartStartCharStyles = new[] { 'f', 'x', 'z' };
 
@@ -95,8 +91,6 @@ namespace SIL.Machine.Corpora
             IReadOnlyList<UsfmAttribute> attributes
         )
         {
-            if (IsPreserveParagraphType(marker))
-                _inPreservedParagraph = true;
             if (_curVerseRef.IsDefault)
                 UpdateVerseRef(state.VerseRef, marker);
 
@@ -109,7 +103,6 @@ namespace SIL.Machine.Corpora
 
         public override void EndPara(UsfmParserState state, string marker)
         {
-            _inPreservedParagraph = false;
             if (CurrentTextType == ScriptureTextType.NonVerse)
             {
                 EndParentElement();
@@ -391,11 +384,6 @@ namespace SIL.Machine.Corpora
             return _inEmbed || IsEmbedStyle(marker);
         }
 
-        protected bool IsInPreservedParagraph(string marker)
-        {
-            return _inPreservedParagraph || IsPreserveParagraphType(marker);
-        }
-
         protected bool IsInNestedEmbed(string marker)
         {
             return _inNestedEmbed
@@ -420,11 +408,6 @@ namespace SIL.Machine.Corpora
         protected static bool IsEmbedStyle(string marker)
         {
             return !(marker is null) && marker.Trim('*').IsOneOf(EmbedStyles);
-        }
-
-        protected static bool IsPreserveParagraphType(string marker)
-        {
-            return PreserveParagraphStyles.Contains(marker);
         }
     }
 }

--- a/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
+++ b/src/SIL.Machine/Corpora/ScriptureRefUsfmParserHandlerBase.cs
@@ -20,6 +20,7 @@ namespace SIL.Machine.Corpora
         private readonly Stack<ScriptureElement> _curElements;
         private readonly Stack<ScriptureTextType> _curTextType;
         private bool _duplicateVerse = false;
+        private bool _inPreservedParagraph = false;
 
         private bool _inEmbed;
         protected bool InNoteText { get; private set; }
@@ -34,6 +35,7 @@ namespace SIL.Machine.Corpora
         protected ScriptureTextType CurrentTextType =>
             _curTextType.Count == 0 ? ScriptureTextType.None : _curTextType.Peek();
 
+        private static readonly string[] PreserveParagraphStyles = new[] { "r", "rem" };
         private static readonly string[] EmbedStyles = new[] { "f", "fe", "fig", "fm", "x" };
         private static readonly char[] EmbedPartStartCharStyles = new[] { 'f', 'x', 'z' };
 
@@ -93,6 +95,8 @@ namespace SIL.Machine.Corpora
             IReadOnlyList<UsfmAttribute> attributes
         )
         {
+            if (IsPreserveParagraphType(marker))
+                _inPreservedParagraph = true;
             if (_curVerseRef.IsDefault)
                 UpdateVerseRef(state.VerseRef, marker);
 
@@ -105,6 +109,7 @@ namespace SIL.Machine.Corpora
 
         public override void EndPara(UsfmParserState state, string marker)
         {
+            _inPreservedParagraph = false;
             if (CurrentTextType == ScriptureTextType.NonVerse)
             {
                 EndParentElement();
@@ -386,6 +391,11 @@ namespace SIL.Machine.Corpora
             return _inEmbed || IsEmbedStyle(marker);
         }
 
+        protected bool IsInPreservedParagraph(string marker)
+        {
+            return _inPreservedParagraph || IsPreserveParagraphType(marker);
+        }
+
         protected bool IsInNestedEmbed(string marker)
         {
             return _inNestedEmbed
@@ -409,7 +419,12 @@ namespace SIL.Machine.Corpora
 
         protected static bool IsEmbedStyle(string marker)
         {
-            return !(marker is null) && marker.IsOneOf(EmbedStyles);
+            return !(marker is null) && marker.Trim('*').IsOneOf(EmbedStyles);
+        }
+
+        protected static bool IsPreserveParagraphType(string marker)
+        {
+            return PreserveParagraphStyles.Contains(marker);
         }
     }
 }

--- a/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
+++ b/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
+using SIL.ObjectModel;
 
 namespace SIL.Machine.Corpora
 {
@@ -33,7 +33,7 @@ namespace SIL.Machine.Corpora
         private readonly UpdateUsfmMarkerBehavior _paragraphBehavior;
         private readonly UpdateUsfmMarkerBehavior _embedBehavior;
         private readonly UpdateUsfmMarkerBehavior _styleBehavior;
-        private readonly ImmutableHashSet<string> _preserveParagraphStyles;
+        private readonly IReadOnlySet<string> _preserveParagraphStyles;
         private readonly Stack<bool> _replace;
         private int _rowIndex;
         private int _tokenIndex;
@@ -48,7 +48,7 @@ namespace SIL.Machine.Corpora
             UpdateUsfmMarkerBehavior paragraphBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
             UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip,
-            ImmutableHashSet<string> preserveParagraphStyles = null
+            IReadOnlyCollection<string> preserveParagraphStyles = null
         )
         {
             _rows = rows ?? Array.Empty<(IReadOnlyList<ScriptureRef>, string)>();
@@ -62,9 +62,9 @@ namespace SIL.Machine.Corpora
             _embedBehavior = embedBehavior;
             _styleBehavior = styleBehavior;
             if (preserveParagraphStyles == null)
-                _preserveParagraphStyles = ImmutableHashSet.Create("r", "rem");
+                _preserveParagraphStyles = (IReadOnlySet<string>)new HashSet<string> { "r", "rem" };
             else
-                _preserveParagraphStyles = preserveParagraphStyles;
+                _preserveParagraphStyles = (IReadOnlySet<string>)new HashSet<string>(preserveParagraphStyles);
             _embedUpdated = false;
             _embedRowTexts = new List<string>();
         }

--- a/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
+++ b/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SIL.ObjectModel;
 
 namespace SIL.Machine.Corpora
 {
@@ -33,7 +32,7 @@ namespace SIL.Machine.Corpora
         private readonly UpdateUsfmMarkerBehavior _paragraphBehavior;
         private readonly UpdateUsfmMarkerBehavior _embedBehavior;
         private readonly UpdateUsfmMarkerBehavior _styleBehavior;
-        private readonly IReadOnlySet<string> _preserveParagraphStyles;
+        private readonly HashSet<string> _preserveParagraphStyles;
         private readonly Stack<bool> _replace;
         private int _rowIndex;
         private int _tokenIndex;
@@ -62,9 +61,9 @@ namespace SIL.Machine.Corpora
             _embedBehavior = embedBehavior;
             _styleBehavior = styleBehavior;
             if (preserveParagraphStyles == null)
-                _preserveParagraphStyles = (IReadOnlySet<string>)new HashSet<string> { "r", "rem" };
+                _preserveParagraphStyles = new HashSet<string> { "r", "rem" };
             else
-                _preserveParagraphStyles = (IReadOnlySet<string>)new HashSet<string>(preserveParagraphStyles);
+                _preserveParagraphStyles = new HashSet<string>(preserveParagraphStyles);
             _embedUpdated = false;
             _embedRowTexts = new List<string>();
         }

--- a/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
@@ -33,11 +33,68 @@ public class UpdateUsfmParserHandlerTests
     [Test]
     public void GetUsfm_StripAllText()
     {
-        string target = UpdateUsfm(textBehavior: UpdateUsfmTextBehavior.StripExisting);
-        Assert.That(target, Contains.Substring("\\id MAT\r\n"));
-        Assert.That(target, Contains.Substring("\\v 1\r\n"));
-        Assert.That(target, Contains.Substring("\\s\r\n"));
-        Assert.That(target, Contains.Substring("\\ms\r\n"));
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:1"), "Update 1"),
+            (ScrRef("MAT 1:3"), "Update 3")
+        };
+        var usfm =
+            @"\id MAT - Test
+\c 1
+\r keep this reference
+\rem and this reference too
+\ip but remove this text
+\v 1 Chapter \add one\add*, \p verse \f + \fr 2:1: \ft This is a \fm ∆\fm* footnote.\f*one.
+\v 2 Chapter \add one\add*, \p verse \f + \fr 2:1: \ft This is a \fm ∆\fm* footnote.\f*two.
+\v 3 Verse 3
+\v 4 Verse 4
+";
+
+        string target = UpdateUsfm(
+            rows,
+            usfm,
+            textBehavior: UpdateUsfmTextBehavior.StripExisting,
+            paragraphBehavior: UpdateUsfmMarkerBehavior.Preserve,
+            embedBehavior: UpdateUsfmMarkerBehavior.Preserve,
+            styleBehavior: UpdateUsfmMarkerBehavior.Preserve
+        );
+
+        var result =
+            @"\id MAT
+\c 1
+\r keep this reference
+\rem and this reference too
+\ip
+\v 1 Update 1 \add \add*
+\p \f + \fr 2:1: \ft \fm ∆\fm*\f*
+\v 2 \add \add*
+\p \f + \fr 2:1: \ft \fm ∆\fm*\f*
+\v 3 Update 3
+\v 4
+";
+        Assess(target, result);
+
+        target = UpdateUsfm(
+            rows,
+            usfm,
+            textBehavior: UpdateUsfmTextBehavior.StripExisting,
+            paragraphBehavior: UpdateUsfmMarkerBehavior.Strip,
+            embedBehavior: UpdateUsfmMarkerBehavior.Strip,
+            styleBehavior: UpdateUsfmMarkerBehavior.Strip
+        );
+
+        result =
+            @"\id MAT
+\c 1
+\r keep this reference
+\rem and this reference too
+\ip
+\v 1 Update 1
+\v 2
+\v 3 Update 3
+\v 4
+";
+        Assess(target, result);
     }
 
     [Test]
@@ -549,6 +606,95 @@ public class UpdateUsfmParserHandlerTests
     }
 
     [Test]
+    public void GetUsfm_StripParagraphs()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:0/2:p"), "Update Paragraph"),
+            (ScrRef("MAT 1:1"), "Update Verse 1")
+        };
+
+        var usfm =
+            @"\id MAT - Test
+\c 1
+\p This is a paragraph before any verses
+\p This is a second paragraph before any verses
+\v 1 Hello
+\p World
+\v 2 Hello
+\p World
+";
+
+        string target = UpdateUsfm(rows, usfm, paragraphBehavior: UpdateUsfmMarkerBehavior.Preserve);
+        var resultP =
+            @"\id MAT - Test
+\c 1
+\p This is a paragraph before any verses
+\p Update Paragraph
+\v 1 Update Verse 1
+\p
+\v 2 Hello
+\p World
+";
+        Assess(target, resultP);
+
+        target = UpdateUsfm(rows, usfm, paragraphBehavior: UpdateUsfmMarkerBehavior.Strip);
+        var resultS =
+            @"\id MAT - Test
+\c 1
+\p This is a paragraph before any verses
+\p Update Paragraph
+\v 1 Update Verse 1
+\v 2 Hello
+\p World
+";
+        Assess(target, resultS);
+    }
+
+    [Test]
+    public void GetUsfm_PreservationRawStrings()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)>
+        {
+            (ScrRef("MAT 1:1"), @"Update all in one row \f \fr 1.1 \ft Some note \f*")
+        };
+
+        var usfm =
+            @"\id MAT - Test
+\c 1
+\v 1 \f \fr 1.1 \ft Some note \f*Hello World
+";
+
+        string target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
+        var result =
+            @"\id MAT - Test
+\c 1
+\v 1 Update all in one row \f \fr 1.1 \ft Some note \f*
+";
+        Assess(target, result);
+    }
+
+    [Test]
+    public void GetUsfm_BeginningOfVerseEmbed()
+    {
+        var rows = new List<(IReadOnlyList<ScriptureRef>, string)> { (ScrRef("MAT 1:1"), @"Updated text") };
+
+        var usfm =
+            @"\id MAT - Test
+\c 1
+\v 1 \f \fr 1.1 \ft Some note \f* Text after note
+";
+
+        string target = UpdateUsfm(rows, usfm, embedBehavior: UpdateUsfmMarkerBehavior.Strip);
+        var result =
+            @"\id MAT - Test
+\c 1
+\v 1 Updated text
+";
+        Assess(target, result);
+    }
+
+    [Test]
     public void EmptyNote()
     {
         var rows = new List<(IReadOnlyList<ScriptureRef>, string)> { (ScrRef("MAT 1:1/1:f"), "Update the note") };
@@ -705,6 +851,7 @@ public class UpdateUsfmParserHandlerTests
         string? source = null,
         string? idText = null,
         UpdateUsfmTextBehavior textBehavior = UpdateUsfmTextBehavior.PreferNew,
+        UpdateUsfmMarkerBehavior paragraphBehavior = UpdateUsfmMarkerBehavior.Preserve,
         UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
         UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip
     )
@@ -712,12 +859,27 @@ public class UpdateUsfmParserHandlerTests
         if (source is null)
         {
             var updater = new FileParatextProjectTextUpdater(CorporaTestHelpers.UsfmTestProjectPath);
-            return updater.UpdateUsfm("MAT", rows, idText, textBehavior, embedBehavior, styleBehavior);
+            return updater.UpdateUsfm(
+                "MAT",
+                rows,
+                idText,
+                textBehavior,
+                paragraphBehavior,
+                embedBehavior,
+                styleBehavior
+            );
         }
         else
         {
             source = source.Trim().ReplaceLineEndings("\r\n") + "\r\n";
-            var updater = new UpdateUsfmParserHandler(rows, idText, textBehavior, embedBehavior, styleBehavior);
+            var updater = new UpdateUsfmParserHandler(
+                rows,
+                idText,
+                textBehavior,
+                paragraphBehavior,
+                embedBehavior,
+                styleBehavior
+            );
             UsfmParser.Parse(source, updater);
             return updater.GetUsfm();
         }
@@ -730,7 +892,7 @@ public class UpdateUsfmParserHandlerTests
         var truth_lines = truth.Split(new[] { "\n" }, StringSplitOptions.None);
         for (int i = 0; i < truth_lines.Length; i++)
         {
-            Assert.That(target_lines[i].Trim(), Is.EqualTo(truth_lines[i].Trim()));
+            Assert.That(target_lines[i].Trim(), Is.EqualTo(truth_lines[i].Trim()), message: $"Line {i}");
         }
     }
 }

--- a/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
@@ -945,7 +945,7 @@ public class UpdateUsfmParserHandlerTests
         UpdateUsfmMarkerBehavior paragraphBehavior = UpdateUsfmMarkerBehavior.Preserve,
         UpdateUsfmMarkerBehavior embedBehavior = UpdateUsfmMarkerBehavior.Preserve,
         UpdateUsfmMarkerBehavior styleBehavior = UpdateUsfmMarkerBehavior.Strip,
-        ImmutableHashSet<string>? preserveParagraphStyles = null
+        IReadOnlyCollection<string>? preserveParagraphStyles = null
     )
     {
         if (source is null)


### PR DESCRIPTION
Add tests for beginning-of-verse embeds
Fix the embed at beginning issue (https://github.com/sillsdev/serval/issues/636)
Add paragraph marker control (https://github.com/sillsdev/serval/issues/627)
Always preserve \r and \rem
Correct behavior for stripping text behavior (https://github.com/sillsdev/serval/issues/629)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/291)
<!-- Reviewable:end -->
