### PR TITLE
Fix faulty edge-case logic in NParallelTextCorpus

### DIFF
--- a/src/SIL.Machine/Corpora/NParallelTextCorpus.cs
+++ b/src/SIL.Machine/Corpora/NParallelTextCorpus.cs
@@ -71,9 +71,9 @@ namespace SIL.Machine.Corpora
             }
         }
 
-        private static bool AllInRangeHaveSegments(IList<TextRow> rows)
+        private static bool AllRangesAreNewRanges(IList<TextRow> rows)
         {
-            return rows.All(r => (r.IsInRange && !r.IsEmpty) || (!r.IsInRange));
+            return rows.All(r => r.IsRangeStart || !r.IsInRange);
         }
 
         private IList<int> MinRefIndexes(IList<object> refs)
@@ -211,7 +211,7 @@ namespace SIL.Machine.Corpora
                     {
                         if (
                             rangeInfo.IsInRange
-                            && AllInRangeHaveSegments(currentRows.Where((r, i) => !completed[i]).ToArray())
+                            && AllRangesAreNewRanges(currentRows.Where((r, i) => !completed[i]).ToArray())
                         )
                         {
                             yield return rangeInfo.CreateRow();

--- a/tests/SIL.Machine.Tests/Corpora/ParallelTextCorpusTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParallelTextCorpusTests.cs
@@ -600,6 +600,61 @@ public class ParallelTextCorpusTests
     }
 
     [Test]
+    public void GetRows_AdjacentRangesBothTexts_EmptyTargetSegments()
+    {
+        var sourceCorpus = new DictionaryTextCorpus(
+            new MemoryText(
+                "text1",
+                new[]
+                {
+                    TextRow(
+                        "text1",
+                        1,
+                        "source segment 1 . source segment 2 .",
+                        TextRowFlags.InRange | TextRowFlags.RangeStart
+                    ),
+                    TextRow("text1", 2, flags: TextRowFlags.InRange),
+                    TextRow(
+                        "text1",
+                        3,
+                        "source segment 3 . source segment 4 .",
+                        TextRowFlags.InRange | TextRowFlags.RangeStart
+                    ),
+                    TextRow("text1", 4, flags: TextRowFlags.InRange)
+                }
+            )
+        );
+        var targetCorpus = new DictionaryTextCorpus(
+            new MemoryText(
+                "text1",
+                new[]
+                {
+                    TextRow("text1", 1, flags: TextRowFlags.InRange | TextRowFlags.RangeStart),
+                    TextRow("text1", 2, flags: TextRowFlags.InRange),
+                    TextRow("text1", 3, flags: TextRowFlags.InRange | TextRowFlags.RangeStart),
+                    TextRow("text1", 4, flags: TextRowFlags.InRange)
+                }
+            )
+        );
+
+        var parallelCorpus = new ParallelTextCorpus(sourceCorpus, targetCorpus)
+        {
+            AllSourceRows = true,
+            AllTargetRows = false
+        };
+        ParallelTextRow[] rows = parallelCorpus.ToArray();
+        Assert.That(rows.Length, Is.EqualTo(2));
+        Assert.That(rows[0].SourceRefs, Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(rows[0].TargetRefs, Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(rows[0].SourceSegment, Is.EqualTo("source segment 1 . source segment 2 .".Split()));
+        Assert.That(rows[0].TargetSegment, Is.Empty);
+        Assert.That(rows[1].SourceRefs, Is.EqualTo(new[] { 3, 4 }));
+        Assert.That(rows[1].TargetRefs, Is.EqualTo(new[] { 3, 4 }));
+        Assert.That(rows[1].SourceSegment, Is.EqualTo("source segment 3 . source segment 4 .".Split()));
+        Assert.That(rows[1].TargetSegment, Is.Empty);
+    }
+
+    [Test]
     public void GetRows_AllSourceRows()
     {
         var sourceCorpus = new DictionaryTextCorpus(


### PR DESCRIPTION
Fixes https://github.com/sillsdev/machine/issues/294

This was a bug that already existed in the previous `ParallelTextCorpus` implementation. We were relying on segment count as an indicator of a new range starting when we should just have used the `IsRangeStart` property since this isn't reliable when your target is totally empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/295)
<!-- Reviewable:end -->
