### PR TITLE
Improve error handling for Hermit Crab users

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -103,9 +103,11 @@ namespace SIL.Machine.Morphology.HermitCrab
         {
             public CompileException() { }
 
-            public CompileException(string message): base(message) { }
+            public CompileException(string message)
+                : base(message) { }
 
-            public CompileException(string message, Exception inner): base(message, inner) { }
+            public CompileException(string message, Exception inner)
+                : base(message, inner) { }
         }
 
         public IEnumerable<Word> Apply(Word input)

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -101,19 +101,11 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public class CompileException : Exception
         {
-            public CompileException()
-            {
-            }
+            public CompileException() { }
 
-            public CompileException(string message)
-                : base(message)
-            {
-            }
+            public CompileException(string message): base(message) { }
 
-            public CompileException(string message, Exception inner)
-                : base(message, inner)
-            {
-            }
+            public CompileException(string message, Exception inner): base(message, inner) { }
         }
 
         public IEnumerable<Word> Apply(Word input)

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -99,17 +99,6 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
         }
 
-        public class CompileException : Exception
-        {
-            public CompileException() { }
-
-            public CompileException(string message)
-                : base(message) { }
-
-            public CompileException(string message, Exception inner)
-                : base(message, inner) { }
-        }
-
         public IEnumerable<Word> Apply(Word input)
         {
             if (_morpher.TraceManager.IsTracing)

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using SIL.Machine.Annotations;
@@ -20,16 +21,16 @@ namespace SIL.Machine.Morphology.HermitCrab
             _stratum = stratum;
             _morpher = morpher;
             _prulesRule = new LinearRuleCascade<Word, ShapeNode>(
-                stratum.PhonologicalRules.Select(prule => prule.CompileAnalysisRule(morpher)).Reverse()
+                stratum.PhonologicalRules.Select(prule => CompilePhonologicalRule(prule, morpher)).Reverse()
             );
             _templatesRule = new RuleBatch<Word, ShapeNode>(
-                stratum.AffixTemplates.Select(template => template.CompileAnalysisRule(morpher)),
+                stratum.AffixTemplates.Select(template => CompileAffixTemplate(template, morpher)),
                 false,
                 FreezableEqualityComparer<Word>.Default
             );
             _mrulesRule = null;
             IEnumerable<IRule<Word, ShapeNode>> mrules = stratum
-                .MorphologicalRules.Select(mrule => mrule.CompileAnalysisRule(morpher))
+                .MorphologicalRules.Select(mrule => CompileMorphologicalRule(mrule, morpher))
                 .Reverse();
             switch (stratum.MorphologicalRuleOrder)
             {
@@ -59,6 +60,42 @@ namespace SIL.Machine.Morphology.HermitCrab
                     );
 #endif
                     break;
+            }
+        }
+
+        private IRule<Word, ShapeNode> CompileAffixTemplate(AffixTemplate template, Morpher morpher)
+        {
+            try
+            {
+                return template.CompileAnalysisRule(morpher);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Could not compile affix template named " + template.Name, e);
+            }
+        }
+
+        private IRule<Word, ShapeNode> CompileMorphologicalRule(IMorphologicalRule mrule, Morpher morpher)
+        {
+            try
+            {
+                return mrule.CompileAnalysisRule(morpher);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Could not compile morphological rule named " + mrule.Name, e);
+            }
+        }
+
+         private IRule<Word, ShapeNode> CompilePhonologicalRule(IPhonologicalRule prule, Morpher morpher)
+        {
+            try
+            {
+                return prule.CompileAnalysisRule(morpher);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Could not compile phonological rule named " + prule.Name, e);
             }
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -87,7 +87,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
         }
 
-         private IRule<Word, ShapeNode> CompilePhonologicalRule(IPhonologicalRule prule, Morpher morpher)
+        private IRule<Word, ShapeNode> CompilePhonologicalRule(IPhonologicalRule prule, Morpher morpher)
         {
             try
             {

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -71,7 +71,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
             catch (Exception e)
             {
-                throw new Exception("Could not compile affix template named " + template.Name, e);
+                throw new CompileException("Could not compile affix template named " + template.Name, e);
             }
         }
 
@@ -83,7 +83,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
             catch (Exception e)
             {
-                throw new Exception("Could not compile morphological rule named " + mrule.Name, e);
+                throw new CompileException("Could not compile morphological rule named " + mrule.Name, e);
             }
         }
 
@@ -95,7 +95,24 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
             catch (Exception e)
             {
-                throw new Exception("Could not compile phonological rule named " + prule.Name, e);
+                throw new CompileException("Could not compile phonological rule named " + prule.Name, e);
+            }
+        }
+
+        public class CompileException : Exception
+        {
+            public CompileException()
+            {
+            }
+
+            public CompileException(string message)
+                : base(message)
+            {
+            }
+
+            public CompileException(string message, Exception inner)
+                : base(message, inner)
+            {
             }
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/CompileException.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/CompileException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SIL.Machine.Morphology.HermitCrab
+{
+    public class CompileException : Exception
+    {
+        public CompileException() { }
+
+        public CompileException(string message)
+            : base(message) { }
+
+        public CompileException(string message, Exception inner)
+            : base(message, inner) { }
+    }
+}


### PR DESCRIPTION
I wrapped exceptions in the Hermit Crab compiler so that the user would know which rule couldn't be compiled.  This may allow the user to fix the rule causing the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/307)
<!-- Reviewable:end -->
