### PR TITLE
LT-22156

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/Allomorph.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Allomorph.cs
@@ -157,22 +157,25 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         protected virtual bool CheckAllomorphConstraints(Morpher morpher, Allomorph allomorph, Word word)
         {
-            if (
-                AllomorphCoOccurrenceRules.Count > 0
-                && !AllomorphCoOccurrenceRules.Any(r => r.IsWordValid(allomorph, word))
-            )
+            if (AllomorphCoOccurrenceRules.Count > 0)
             {
-                if (morpher != null && morpher.TraceManager.IsTracing)
+                foreach (var rule in AllomorphCoOccurrenceRules)
                 {
-                    morpher.TraceManager.Failed(
-                        morpher.Language,
-                        word,
-                        FailureReason.AllomorphCoOccurrenceRules,
-                        this,
-                        AllomorphCoOccurrenceRules
-                    );
+                    if (!rule.IsWordValid(allomorph, word))
+                    {
+                        if (morpher != null && morpher.TraceManager.IsTracing)
+                        {
+                            morpher.TraceManager.Failed(
+                                morpher.Language,
+                                word,
+                                FailureReason.AllomorphCoOccurrenceRules,
+                                this,
+                                rule
+                            );
+                        }
+                        return false;
+                    }
                 }
-                return false;
             }
 
             if (Morpheme.MorphemeCoOccurrenceRules.Count > 0)

--- a/src/SIL.Machine.Morphology.HermitCrab/Allomorph.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Allomorph.cs
@@ -175,22 +175,26 @@ namespace SIL.Machine.Morphology.HermitCrab
                 return false;
             }
 
-            if (
-                Morpheme.MorphemeCoOccurrenceRules.Count > 0
-                && !Morpheme.MorphemeCoOccurrenceRules.Any(r => r.IsWordValid(Morpheme, word))
-            )
+            if (Morpheme.MorphemeCoOccurrenceRules.Count > 0)
             {
-                if (morpher != null && morpher.TraceManager.IsTracing)
+                foreach (MorphemeCoOccurrenceRule rule in Morpheme.MorphemeCoOccurrenceRules)
                 {
-                    morpher.TraceManager.Failed(
-                        morpher.Language,
-                        word,
-                        FailureReason.MorphemeCoOccurrenceRules,
-                        this,
-                        Morpheme.MorphemeCoOccurrenceRules
-                    );
+                    // We need to check each one in turn and report any failure
+                    if (!rule.IsWordValid(Morpheme, word))
+                    {
+                        if (morpher != null && morpher.TraceManager.IsTracing)
+                        {
+                            morpher.TraceManager.Failed(
+                            morpher.Language,
+                            word,
+                            FailureReason.MorphemeCoOccurrenceRules,
+                            this,
+                            rule
+                            );
+                        }
+                        return false;
+                    }
                 }
-                return false;
             }
 
             return true;


### PR DESCRIPTION
FLEx Ad hoc rules involving a clitic do not block in Hermit Crab.
There are two entries for these: one as a stem and one as an affix.
Any co-occurrence rules for these involve two items.  The current code does not find a failure and does not report the failing rule.
The code fixes this for both morpheme and allomorph co-occurrence rules and includes new test cases for them.