### PR TITLE
Fix for LT-18767 Yellow crash foe XAmple-style redup pattern

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/CopyFromInput.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/CopyFromInput.cs
@@ -18,6 +18,14 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             IDictionary<string, int> capturedParts
         )
         {
+            if (!partLookup.ContainsKey(PartName))
+                // The key can be missing when using XAmple-style partial reduplication patterns
+                // and the environment does not have a matching indexed natural class.
+                // For example, [C^1][V^1][C^2][C^3] /[C^1][V^1][C^2]h_
+                // where there is no [C^3] in the environment.
+                // We skip it here.  N.B. XAmple does not give any warning message about it, either.
+                // This fixes LT-18767.
+                return;
             Pattern<Word, ShapeNode> pattern = partLookup[PartName];
             int count = capturedParts.GetOrCreate(PartName, () => 0);
             string groupName = AnalysisMorphologicalTransform.GetGroupName(PartName, count);


### PR DESCRIPTION
When using an XAmple-style reduplication pattern, if there was an indexed natural class in the pattern that was not also in the environment, then Hermit Crab threw a key not found exception.  This by-passes that.

Note: I wanted to create a unit test case for this but did not know how to create the reduplication information in an Allomorph.  So there is no unit test case for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/313)
<!-- Reviewable:end -->
