### PR TITLE
LT-22190 Use BitArray for large symbolic feature value sets

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/CharacterDefinition.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/CharacterDefinition.cs
@@ -19,7 +19,11 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public FeatureSymbol Type
         {
-            get { return (FeatureSymbol)_fs.GetValue(HCFeatureSystem.Type); }
+            get
+            {
+                FeatureSymbol fsym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(_fs, HCFeatureSystem.Type);
+                return fsym;
+            }
         }
 
         public ReadOnlyCollection<string> Representations

--- a/src/SIL.Machine.Morphology.HermitCrab/HCFeatureSystem.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/HCFeatureSystem.cs
@@ -51,7 +51,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             Modified = new SymbolicFeature(Guid.NewGuid().ToString(), Dirty, Clean)
             {
                 Description = "Modified",
-                DefaultValue = new SymbolicFeatureValue(Clean)
+                DefaultValue = SymbolicFeatureValueFactory.Instance.Create(Clean)
             };
 
             Deleted = new FeatureSymbol(Guid.NewGuid().ToString()) { Description = "Deleted" };
@@ -60,7 +60,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             Deletion = new SymbolicFeature(Guid.NewGuid().ToString(), Deleted, NotDeleted)
             {
                 Description = "Deletion",
-                DefaultValue = new SymbolicFeatureValue(NotDeleted)
+                DefaultValue = SymbolicFeatureValueFactory.Instance.Create(NotDeleted)
             };
 
             LeftSide = new FeatureSymbol(Guid.NewGuid().ToString()) { Description = "LeftSide" };

--- a/src/SIL.Machine.Morphology.HermitCrab/HermitCrabExtensions.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/HermitCrabExtensions.cs
@@ -13,17 +13,29 @@ namespace SIL.Machine.Morphology.HermitCrab
     {
         public static FeatureSymbol Type(this ShapeNode node)
         {
-            return (FeatureSymbol)node.Annotation.FeatureStruct.GetValue(HCFeatureSystem.Type);
+            FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                node.Annotation.FeatureStruct,
+                HCFeatureSystem.Type
+            );
+            return fSym;
         }
 
         public static FeatureSymbol Type(this Annotation<ShapeNode> ann)
         {
-            return (FeatureSymbol)ann.FeatureStruct.GetValue(HCFeatureSystem.Type);
+            FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                ann.FeatureStruct,
+                HCFeatureSystem.Type
+            );
+            return fSym;
         }
 
         public static FeatureSymbol Type(this Constraint<Word, ShapeNode> constraint)
         {
-            return (FeatureSymbol)constraint.FeatureStruct.GetValue(HCFeatureSystem.Type);
+            FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                constraint.FeatureStruct,
+                HCFeatureSystem.Type
+            );
+            return fSym;
         }
 
         internal static FeatureStruct AntiFeatureStruct(this FeatureStruct fs)
@@ -55,8 +67,13 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         internal static bool IsDirty(this ShapeNode node)
         {
-            return ((FeatureSymbol)node.Annotation.FeatureStruct.GetValue(HCFeatureSystem.Modified))
-                == HCFeatureSystem.Dirty;
+            FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                node.Annotation.FeatureStruct,
+                HCFeatureSystem.Modified
+            );
+            return fSym == HCFeatureSystem.Dirty;
+            //return ((FeatureSymbol)node.Annotation.FeatureStruct.GetValue(HCFeatureSystem.Modified))
+            //    == HCFeatureSystem.Dirty;
         }
 
         internal static void SetDirty(this ShapeNode node, bool dirty)
@@ -71,7 +88,13 @@ namespace SIL.Machine.Morphology.HermitCrab
         {
             SymbolicFeatureValue sfv;
             if (ann.FeatureStruct.TryGetValue(HCFeatureSystem.Deletion, out sfv))
-                return ((FeatureSymbol)sfv) == HCFeatureSystem.Deleted;
+            {
+                FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                    ann.FeatureStruct,
+                    HCFeatureSystem.Deleted.Feature
+                );
+                return fSym == HCFeatureSystem.Deleted;
+            }
             return false;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisMorphologicalTransform.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisMorphologicalTransform.cs
@@ -96,7 +96,11 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 {
                     foreach (ShapeNode node in output.GetNodes(outputRange))
                     {
-                        if ((FeatureSymbol)modifyFromFS.GetValue(HCFeatureSystem.Type) == node.Annotation.Type())
+                        FeatureSymbol fsym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                            modifyFromFS,
+                            HCFeatureSystem.Type
+                        );
+                        if (fsym == node.Annotation.Type())
                             node.Annotation.FeatureStruct.Add(modifyFromFS, match.VariableBindings);
                     }
                 }

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/ModifyFromInput.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/ModifyFromInput.cs
@@ -44,7 +44,13 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 Constraint<Word, ShapeNode> constraint in group
                     .GetNodesDepthFirst()
                     .OfType<Constraint<Word, ShapeNode>>()
-                    .Where(c => c.Type() == (FeatureSymbol)_simpleCtxt.FeatureStruct.GetValue(HCFeatureSystem.Type))
+                    .Where(c =>
+                        c.Type()
+                        == SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                            _simpleCtxt.FeatureStruct,
+                            HCFeatureSystem.Type
+                        )
+                    )
             )
             {
                 constraint.FeatureStruct.PriorityUnion(_simpleCtxt.FeatureStruct);
@@ -65,7 +71,10 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 ShapeNode outputNode = inputNode.Clone();
                 if (
                     outputNode.Annotation.Type()
-                    == (FeatureSymbol)_simpleCtxt.FeatureStruct.GetValue(HCFeatureSystem.Type)
+                    == SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        _simpleCtxt.FeatureStruct,
+                        HCFeatureSystem.Type
+                    )
                 )
                 {
                     outputNode.Annotation.FeatureStruct.PriorityUnion(

--- a/src/SIL.Machine.Morphology.HermitCrab/XmlLanguageLoader.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/XmlLanguageLoader.cs
@@ -1450,7 +1450,7 @@ namespace SIL.Machine.Morphology.HermitCrab
                 var varID = (string)varElem.Attribute("variableFeature");
                 Tuple<string, SymbolicFeature> variable = variables[varID];
                 ctxtVars.Add(
-                    new SymbolicFeatureValue(
+                    SymbolicFeatureValueFactory.Instance.Create(
                         variable.Item2,
                         variable.Item1,
                         ((string)varElem.Attribute("polarity") ?? "plus") == "plus"

--- a/src/SIL.Machine.Morphology.HermitCrab/XmlLanguageWriter.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/XmlLanguageWriter.cs
@@ -1139,7 +1139,10 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (node is Constraint<Word, ShapeNode> constraint)
             {
                 return constraint.Type() == HCFeatureSystem.Anchor
-                    && (FeatureSymbol)constraint.FeatureStruct.GetValue(HCFeatureSystem.AnchorType) == type;
+                    && SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        constraint.FeatureStruct,
+                        HCFeatureSystem.AnchorType
+                    ) == type;
             }
 
             return false;

--- a/src/SIL.Machine/FeatureModel/FeatureStruct.cs
+++ b/src/SIL.Machine/FeatureModel/FeatureStruct.cs
@@ -53,6 +53,7 @@ namespace SIL.Machine.FeatureModel
 
         private readonly IDBearerDictionary<Feature, FeatureValue> _definite;
         private int? _hashCode;
+        private readonly SymbolicFeatureValueFactory _valueFactory = SymbolicFeatureValueFactory.Instance;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FeatureStruct"/> class.
@@ -126,15 +127,12 @@ namespace SIL.Machine.FeatureModel
                 throw new ArgumentNullException("values");
 
             FeatureSymbol[] vals = values.ToArray();
-            AddValue(feature, vals.Length == 0 ? new SymbolicFeatureValue(feature) : new SymbolicFeatureValue(vals));
+            AddValue(feature, vals.Length == 0 ? _valueFactory.Create(feature) : _valueFactory.Create(vals));
         }
 
         public void AddValue(SymbolicFeature feature, params FeatureSymbol[] values)
         {
-            AddValue(
-                feature,
-                values.Length == 0 ? new SymbolicFeatureValue(feature) : new SymbolicFeatureValue(values)
-            );
+            AddValue(feature, values.Length == 0 ? _valueFactory.Create(feature) : _valueFactory.Create(values));
         }
 
         public void AddValue(StringFeature feature, IEnumerable<string> values)
@@ -456,7 +454,7 @@ namespace SIL.Machine.FeatureModel
                             else if (otherValue is StringFeatureValue)
                                 thisValue = new StringFeatureValue();
                             else
-                                thisValue = new SymbolicFeatureValue((SymbolicFeature)featVal.Key);
+                                thisValue = _valueFactory.Create((SymbolicFeature)featVal.Key);
                             _definite[featVal.Key] = thisValue;
                         }
                         if (!thisValue.AddImpl(otherValue, varBindings, visited))

--- a/src/SIL.Machine/FeatureModel/Fluent/FeatureStructBuilder.cs
+++ b/src/SIL.Machine/FeatureModel/Fluent/FeatureStructBuilder.cs
@@ -10,6 +10,7 @@ namespace SIL.Machine.FeatureModel.Fluent
         private readonly FeatureStruct _fs;
         private readonly IDictionary<int, FeatureValue> _ids;
         private readonly bool _mutable;
+        private readonly SymbolicFeatureValueFactory _valueFactory = SymbolicFeatureValueFactory.Instance;
 
         private Feature _lastFeature;
         private bool _not;
@@ -242,7 +243,7 @@ namespace SIL.Machine.FeatureModel.Fluent
             if (symbols.Any(s => s.Feature != feature))
                 return false;
             var symbolFeature = (SymbolicFeature)feature;
-            var value = new SymbolicFeatureValue(_not ? symbolFeature.PossibleSymbols.Except(symbols) : symbols);
+            var value = _valueFactory.Create(_not ? symbolFeature.PossibleSymbols.Except(symbols) : symbols);
             _fs.AddValue(symbolFeature, value);
             _not = false;
             if (id > -1)
@@ -441,7 +442,7 @@ namespace SIL.Machine.FeatureModel.Fluent
             if (_lastFeature is StringFeature)
                 vfv = new StringFeatureValue(name, !_not);
             else
-                vfv = new SymbolicFeatureValue((SymbolicFeature)_lastFeature, name, !_not);
+                vfv = _valueFactory.Create((SymbolicFeature)_lastFeature, name, !_not);
             _fs.AddValue(_lastFeature, vfv);
             _not = false;
             if (id > -1)

--- a/src/SIL.Machine/FeatureModel/SimpleFeatureValue.cs
+++ b/src/SIL.Machine/FeatureModel/SimpleFeatureValue.cs
@@ -8,11 +8,15 @@ namespace SIL.Machine.FeatureModel
     {
         public static implicit operator SimpleFeatureValue(FeatureSymbol symbol)
         {
-            return new SymbolicFeatureValue(symbol);
+            return SymbolicFeatureValueFactory.Instance.Create(symbol);
         }
 
         public static explicit operator FeatureSymbol(SimpleFeatureValue sfv)
         {
+            if (sfv is SymbolicFeatureValueBA sfvBA)
+            {
+                return (FeatureSymbol)sfvBA;
+            }
             return (FeatureSymbol)((SymbolicFeatureValue)sfv);
         }
 

--- a/src/SIL.Machine/FeatureModel/SymbolicFeature.cs
+++ b/src/SIL.Machine/FeatureModel/SymbolicFeature.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using SIL.ObjectModel;
 
@@ -7,6 +8,8 @@ namespace SIL.Machine.FeatureModel
     {
         private readonly PossibleSymbolCollection _possibleSymbols;
         private readonly ulong _mask;
+
+        private readonly BitArray _maskBA = new BitArray(sizeof(ulong) * 8, false);
 
         public SymbolicFeature(string id, params FeatureSymbol[] possibleSymbols)
             : this(id, (IEnumerable<FeatureSymbol>)possibleSymbols) { }
@@ -21,7 +24,11 @@ namespace SIL.Machine.FeatureModel
                 symbol.Feature = this;
                 symbol.Index = i++;
             }
-            _mask = (1UL << _possibleSymbols.Count) - 1UL;
+            int symbolCount = _possibleSymbols.Count;
+            if (symbolCount > SymbolicFeatureValueFactory.Instance.NeedToUseBitArray)
+                _maskBA = new BitArray(symbolCount, true);
+            else
+                _mask = (1UL << symbolCount) - 1UL;
         }
 
         /// <summary>
@@ -35,12 +42,17 @@ namespace SIL.Machine.FeatureModel
 
         public string DefaultSymbolID
         {
-            set { DefaultValue = new SymbolicFeatureValue(_possibleSymbols[value]); }
+            set { DefaultValue = SymbolicFeatureValueFactory.Instance.Create(_possibleSymbols[value]); }
         }
 
         internal ulong Mask
         {
             get { return _mask; }
+        }
+
+        internal BitArray MaskBA
+        {
+            get { return _maskBA; }
         }
     }
 }

--- a/src/SIL.Machine/FeatureModel/SymbolicFeatureValueBA.cs
+++ b/src/SIL.Machine/FeatureModel/SymbolicFeatureValueBA.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using SIL.Extensions;
+
+namespace SIL.Machine.FeatureModel
+{
+    // This class uses BitArray instead of ulong for processing symbol feature values
+    // to overcome the 64 value limit that ulong has.
+    public class SymbolicFeatureValueBA : SymbolicFeatureValue
+    {
+        public static implicit operator SymbolicFeatureValueBA(FeatureSymbol symbol)
+        {
+            return new SymbolicFeatureValueBA(symbol);
+        }
+
+        public static explicit operator FeatureSymbol(SymbolicFeatureValueBA sfv)
+        {
+            return sfv._first;
+        }
+
+        private BitArray _flagsBA = new BitArray(sizeof(ulong) * 8, false);
+        private FeatureSymbol _first;
+        private readonly int _bitArraySize;
+
+        public SymbolicFeatureValueBA(SymbolicFeature feature)
+        {
+            Feature = feature;
+            _bitArraySize = Feature.PossibleSymbols.Count;
+            _flagsBA = new BitArray(_bitArraySize, false);
+        }
+
+        public SymbolicFeatureValueBA(IEnumerable<FeatureSymbol> values)
+        {
+            FeatureSymbol[] symbols = values.ToArray();
+            if (symbols.Length == 0)
+                throw new ArgumentException("values cannot be empty", "values");
+            Feature = symbols[0].Feature;
+            _first = symbols[0];
+            _bitArraySize = symbols[0].Feature.PossibleSymbols.Count;
+            _flagsBA = new BitArray(_bitArraySize, false);
+            Set(symbols);
+        }
+
+        public SymbolicFeatureValueBA(FeatureSymbol value)
+        {
+            Feature = value.Feature;
+            _bitArraySize = Feature.PossibleSymbols.Count;
+            _flagsBA = new BitArray(_bitArraySize, false);
+            _first = value;
+            Set(value.ToEnumerable());
+        }
+
+        public SymbolicFeatureValueBA(SymbolicFeature feature, string varName, bool agree)
+            : base(varName, agree)
+        {
+            Feature = feature;
+            _bitArraySize = Feature.PossibleSymbols.Count;
+            _flagsBA = new BitArray(_bitArraySize, false);
+        }
+
+        private SymbolicFeatureValueBA(SymbolicFeatureValueBA sfv)
+            : base(sfv)
+        {
+            Feature = sfv.Feature;
+            _first = sfv._first;
+            _flagsBA = new BitArray(sfv._flagsBA);
+        }
+
+        private SymbolicFeatureValueBA(SymbolicFeature feature, BitArray flagsBA)
+        {
+            Feature = feature;
+            _flagsBA = new BitArray(flagsBA);
+            SetFirst();
+        }
+
+        private void Set(IEnumerable<FeatureSymbol> symbols)
+        {
+            BitArray maskBA = new BitArray(_bitArraySize);
+            foreach (FeatureSymbol symbol in symbols)
+            {
+                maskBA.Set(symbol.Index, true);
+                _flagsBA.Or(maskBA);
+            }
+        }
+
+        public override IEnumerable<FeatureSymbol> Values
+        {
+            get { return Feature.PossibleSymbols.Where(Get); }
+        }
+
+        private void SetFirst()
+        {
+            _first = HasAnySet(_flagsBA) ? Feature.PossibleSymbols.First(Get) : null;
+        }
+
+        protected override bool Get(FeatureSymbol symbol)
+        {
+            return _flagsBA.Get(symbol.Index);
+        }
+
+        // TODO: replace with C# version when available (starting with v.8)
+        private bool HasAnySet(BitArray mask)
+        {
+            foreach (bool flag in mask)
+            {
+                if (flag)
+                    return true;
+            }
+            return false;
+        }
+
+        protected override bool IsSatisfiable
+        {
+            get { return IsVariable || HasAnySet(_flagsBA); }
+        }
+
+        protected override bool IsUninstantiated
+        {
+            get { return !IsVariable && BitArraysAreEqual(_flagsBA, Feature.MaskBA); }
+        }
+
+        private bool BitArraysAreEqual(BitArray array1, BitArray array2)
+        {
+            return array1.Cast<bool>().SequenceEqual(array2.Cast<bool>());
+        }
+
+        protected override bool IsSupersetOf(bool not, SimpleFeatureValue other, bool notOther)
+        {
+            if (!(other is SymbolicFeatureValueBA otherSfv))
+                return false;
+
+            // Since logical operations on BitArrays change the BitArray variable, we need to create temp variables
+            BitArray flags = new BitArray(_flagsBA);
+            BitArray otherFlags = new BitArray(otherSfv._flagsBA);
+            if (!not && !notOther)
+            {
+                return BitArraysAreEqual(flags.And(otherFlags), otherSfv._flagsBA);
+            }
+            else
+            {
+                BitArray notOtherFlags = new BitArray(otherFlags).Not();
+                BitArray notOtherFlagsAndFeatureMask = new BitArray(notOtherFlags.And(Feature.MaskBA));
+                if (!not)
+                {
+                    return BitArraysAreEqual(flags.And(notOtherFlagsAndFeatureMask), notOtherFlagsAndFeatureMask);
+                }
+                else
+                {
+                    BitArray notFlags = new BitArray(_flagsBA).Not();
+                    BitArray notFlagsAndFeatureMask = new BitArray(notFlags.And(Feature.MaskBA));
+                    if (!notOther)
+                    {
+                        return BitArraysAreEqual(notFlagsAndFeatureMask.And(otherSfv._flagsBA), otherSfv._flagsBA);
+                    }
+                    else
+                    {
+                        return BitArraysAreEqual(
+                            notFlagsAndFeatureMask.And(notOtherFlagsAndFeatureMask),
+                            notOtherFlagsAndFeatureMask
+                        );
+                    }
+                }
+            }
+        }
+
+        protected override bool Overlaps(bool not, SimpleFeatureValue other, bool notOther)
+        {
+            if (!(other is SymbolicFeatureValueBA otherSfv))
+            {
+                return false;
+            }
+
+            // Since logical operations on BitArrays change the BitArray variable, we need to create temp variables
+            BitArray flags = new BitArray(_flagsBA);
+            BitArray otherFlags = new BitArray(otherSfv._flagsBA);
+            if (!not && !notOther)
+            {
+                return HasAnySet(flags.And(otherFlags));
+            }
+            else
+            {
+                BitArray notOtherFlags = new BitArray(otherFlags).Not();
+                BitArray notOtherFlagsAndFeatureMask = new BitArray(notOtherFlags.And(Feature.MaskBA));
+                if (!not)
+                {
+                    return HasAnySet(flags.And(notOtherFlagsAndFeatureMask));
+                }
+                else
+                {
+                    BitArray notFlags = new BitArray(_flagsBA).Not();
+                    BitArray notFlagsAndFeatureMask = new BitArray(notFlags.And(Feature.MaskBA));
+                    if (!notOther)
+                    {
+                        return HasAnySet(notFlagsAndFeatureMask.And(otherSfv._flagsBA));
+                    }
+                    else
+                    {
+                        return HasAnySet((notFlagsAndFeatureMask).And(notOtherFlagsAndFeatureMask));
+                    }
+                }
+            }
+        }
+
+        protected override void IntersectWith(bool not, SimpleFeatureValue other, bool notOther)
+        {
+            if (!(other is SymbolicFeatureValueBA otherSfv))
+                return;
+
+            // Since logical operations on BitArrays change the BitArray variable, we need to create temp variables
+            BitArray otherFlags = new BitArray(otherSfv._flagsBA);
+            BitArray flags = new BitArray(_flagsBA);
+            if (!not && !notOther)
+            {
+                _flagsBA = new BitArray(_flagsBA.And(otherSfv._flagsBA));
+            }
+            else
+            {
+                BitArray notOtherFlags = ((BitArray)otherFlags.Clone()).Not();
+                BitArray notOtherFlagsAndFeatureMask = new BitArray(notOtherFlags.And(Feature.MaskBA));
+                if (!not)
+                {
+                    _flagsBA = new BitArray(_flagsBA.And(notOtherFlagsAndFeatureMask));
+                }
+                else
+                {
+                    BitArray notFlags = ((BitArray)flags.Clone()).Not();
+                    BitArray notFlagsAndFeatureMask = new BitArray(notFlags.And(Feature.MaskBA));
+                    if (!notOther)
+                    {
+                        _flagsBA = new BitArray(notFlagsAndFeatureMask.And(otherSfv._flagsBA));
+                    }
+                    else
+                    {
+                        _flagsBA = new BitArray(notFlagsAndFeatureMask.And(notOtherFlagsAndFeatureMask));
+                    }
+                }
+            }
+            SetFirst();
+        }
+
+        protected override void UnionWith(bool not, SimpleFeatureValue other, bool notOther)
+        {
+            if (!(other is SymbolicFeatureValueBA otherSfv))
+                return;
+
+            // Since logical operations on BitArrays change the BitArray variable, we need to create temp variables
+            BitArray flags = new BitArray(_flagsBA);
+            BitArray otherFlags = new BitArray(otherSfv._flagsBA);
+            if (!not && !notOther)
+            {
+                _flagsBA = new BitArray(flags.Or(otherFlags));
+            }
+            else
+            {
+                BitArray notOtherFlags = ((BitArray)otherFlags.Clone()).Not();
+                BitArray notOtherFlagsAndFeatureMask = new BitArray(notOtherFlags.And(Feature.MaskBA));
+                if (!not)
+                {
+                    _flagsBA = new BitArray(_flagsBA.Or(notOtherFlagsAndFeatureMask));
+                }
+                else
+                {
+                    BitArray notFlags = ((BitArray)flags.Clone()).Not();
+                    BitArray notFlagsAndFeatureMask = new BitArray(notFlags.And(Feature.MaskBA));
+                    if (!notOther)
+                    {
+                        _flagsBA = new BitArray(notFlagsAndFeatureMask.Or(otherFlags));
+                    }
+                    else
+                    {
+                        _flagsBA = new BitArray(notFlagsAndFeatureMask.Or(notOtherFlagsAndFeatureMask));
+                    }
+                }
+            }
+            SetFirst();
+        }
+
+        protected override void ExceptWith(bool not, SimpleFeatureValue other, bool notOther)
+        {
+            if (!(other is SymbolicFeatureValueBA otherSfv))
+                return;
+
+            // Since logical operations on BitArrays change the BitArray variable, we need to create temp variables
+            BitArray otherFlags = new BitArray(otherSfv._flagsBA);
+            BitArray notOtherFlags = otherFlags.Not();
+            BitArray notOtherFlagsAndFeatureMask = new BitArray(notOtherFlags.And(Feature.MaskBA));
+            if (!not && !notOther)
+            {
+                _flagsBA.And(notOtherFlagsAndFeatureMask);
+            }
+            else if (!not)
+            {
+                _flagsBA.And(otherSfv._flagsBA);
+            }
+            else
+            {
+                BitArray flags = new BitArray(_flagsBA);
+                BitArray notFlags = ((BitArray)flags.Clone()).Not();
+                BitArray notFlagsAndFeatureMask = new BitArray(notFlags.And(Feature.MaskBA));
+                if (!notOther)
+                {
+                    _flagsBA = notFlagsAndFeatureMask.And(notOtherFlagsAndFeatureMask);
+                }
+                else
+                {
+                    _flagsBA = notFlagsAndFeatureMask.And(otherSfv._flagsBA);
+                }
+            }
+        }
+
+        protected override SimpleFeatureValue CloneImpl()
+        {
+            return Clone();
+        }
+
+        public override SimpleFeatureValue Negation()
+        {
+            // Since logical operations on BitArrays change the BitArray variable, we need to create temp variables
+            BitArray flags = new BitArray(_flagsBA);
+            BitArray notFlagsAndFeatureMask = flags.Not().And(Feature.MaskBA);
+            return IsVariable
+                ? new SymbolicFeatureValueBA(Feature, VariableName, !Agree)
+                : new SymbolicFeatureValueBA(Feature, notFlagsAndFeatureMask);
+        }
+
+        public override bool ValueEquals(SimpleFeatureValue other)
+        {
+            return other is SymbolicFeatureValueBA otherSfv && ValueEquals(otherSfv);
+        }
+
+        public bool ValueEquals(SymbolicFeatureValueBA other)
+        {
+            if (other == null)
+                return false;
+
+            return base.ValueEquals(other) && BitArraysAreEqual(_flagsBA, other._flagsBA);
+        }
+
+        protected override int GetValuesHashCode()
+        {
+            int code = base.GetValuesHashCode();
+            return code * 31 + GetHashCode(_flagsBA);
+        }
+
+        public int GetHashCode(BitArray array)
+        {
+            int hash = 0;
+            foreach (bool value in array)
+            {
+                hash ^= (value ? 2 : 1);
+            }
+            return hash;
+        }
+
+        public new SymbolicFeatureValueBA Clone()
+        {
+            return new SymbolicFeatureValueBA(this);
+        }
+    }
+}

--- a/src/SIL.Machine/FeatureModel/SymbolicFeatureValueFactory.cs
+++ b/src/SIL.Machine/FeatureModel/SymbolicFeatureValueFactory.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SIL.Machine.FeatureModel
+{
+    public class SymbolicFeatureValueFactory
+    {
+        private static readonly Lazy<SymbolicFeatureValueFactory> Lazy = new Lazy<SymbolicFeatureValueFactory>(
+            () => new SymbolicFeatureValueFactory()
+        );
+
+        public static SymbolicFeatureValueFactory Instance
+        {
+            get { return Lazy.Value; }
+        }
+
+        // this can be set to 0 for testing the BitArray code
+        public int NeedToUseBitArray { get; set; } = sizeof(ulong) * 8;
+
+        // To test using the BitArray method, comment the preceding line and uncomment the following line
+        //public int NeedToUseBitArray { get; set; } = 0;
+
+        private SymbolicFeatureValueFactory() { }
+
+        public SymbolicFeatureValue Create(SymbolicFeature feature)
+        {
+            if (feature.PossibleSymbols.Count > NeedToUseBitArray)
+                return new SymbolicFeatureValueBA(feature);
+            return new SymbolicFeatureValue(feature);
+        }
+
+        public SymbolicFeatureValue Create(IEnumerable<FeatureSymbol> values)
+        {
+            FeatureSymbol[] symbols = values.ToArray();
+            if (symbols.Length == 0)
+                throw new ArgumentException("values cannot be empty", "values");
+            if (symbols[0].Feature.PossibleSymbols.Count > NeedToUseBitArray)
+                return new SymbolicFeatureValueBA(values);
+            return new SymbolicFeatureValue(values);
+        }
+
+        public SymbolicFeatureValue Create(FeatureSymbol value)
+        {
+            if (value.Feature.PossibleSymbols.Count > NeedToUseBitArray)
+                return new SymbolicFeatureValueBA(value);
+            return new SymbolicFeatureValue(value);
+        }
+
+        public SymbolicFeatureValue Create(SymbolicFeature feature, string varName, bool agree)
+        {
+            if (feature.PossibleSymbols.Count > NeedToUseBitArray)
+                return new SymbolicFeatureValueBA(feature, varName, agree);
+            return new SymbolicFeatureValue(feature, varName, agree);
+        }
+    }
+}

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/HermitCrabTestBase.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/HermitCrabTestBase.cs
@@ -851,7 +851,7 @@ public abstract class HermitCrabTestBase
         foreach (string symbolID in symbols)
         {
             FeatureSymbol symbol = phoneticFeatSys.GetSymbol(symbolID);
-            fs.AddValue(symbol.Feature, new SymbolicFeatureValue(symbol));
+            fs.AddValue(symbol.Feature, SymbolicFeatureValueFactory.Instance.Create(symbol));
         }
         table.AddSegment(strRep, fs);
     }
@@ -898,7 +898,7 @@ public abstract class HermitCrabTestBase
 
     protected SymbolicFeatureValue Variable(string featureID, string variable, bool agree = true)
     {
-        return new SymbolicFeatureValue(
+        return SymbolicFeatureValueFactory.Instance.Create(
             Language.PhonologicalFeatureSystem.GetFeature<SymbolicFeature>(featureID),
             variable,
             agree

--- a/tests/SIL.Machine.Tests/Matching/MatcherTests.cs
+++ b/tests/SIL.Machine.Tests/Matching/MatcherTests.cs
@@ -1111,7 +1111,17 @@ public class MatcherTests : PhoneticTestsBase
 
         matcher = new Matcher<AnnotatedStringData, int>(
             pattern,
-            new MatcherSettings<int> { Filter = ann => ((FeatureSymbol)ann.FeatureStruct.GetValue(Type)) == Word }
+            new MatcherSettings<int>
+            {
+                Filter = ann =>
+                {
+                    FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        ann.FeatureStruct,
+                        Word.Feature
+                    );
+                    return fSym == Word;
+                }
+            }
         );
         Match<AnnotatedStringData, int> match = matcher.Match(sentence);
         Assert.IsTrue(match.Success);
@@ -1189,7 +1199,17 @@ public class MatcherTests : PhoneticTestsBase
 
         matcher = new Matcher<AnnotatedStringData, int>(
             pattern,
-            new MatcherSettings<int> { Filter = ann => ((FeatureSymbol)ann.FeatureStruct.GetValue(Type)) == Word }
+            new MatcherSettings<int>
+            {
+                Filter = ann =>
+                {
+                    FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        ann.FeatureStruct,
+                        Word.Feature
+                    );
+                    return fSym == Word;
+                }
+            }
         );
         match = matcher.Match(sentence);
         Assert.IsTrue(match.Success);
@@ -1199,7 +1219,14 @@ public class MatcherTests : PhoneticTestsBase
             pattern,
             new MatcherSettings<int>
             {
-                Filter = ann => ((FeatureSymbol)ann.FeatureStruct.GetValue(Type)) == Word,
+                Filter = ann =>
+                {
+                    FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        ann.FeatureStruct,
+                        Word.Feature
+                    );
+                    return fSym == Word;
+                },
                 Direction = Direction.RightToLeft
             }
         );
@@ -1217,7 +1244,15 @@ public class MatcherTests : PhoneticTestsBase
             pattern,
             new MatcherSettings<int>
             {
-                Filter = ann => ((FeatureSymbol)ann.FeatureStruct.GetValue(Type)) != Word,
+                Filter = ann =>
+                {
+                    FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        ann.FeatureStruct,
+                        Word.Feature
+                    );
+                    return fSym != Word;
+                },
+
                 MatchingMethod = MatchingMethod.Unification
             }
         );
@@ -1228,7 +1263,14 @@ public class MatcherTests : PhoneticTestsBase
             pattern,
             new MatcherSettings<int>
             {
-                Filter = ann => ((FeatureSymbol)ann.FeatureStruct.GetValue(Type)) != Word,
+                Filter = ann =>
+                {
+                    FeatureSymbol fSym = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                        ann.FeatureStruct,
+                        Word.Feature
+                    );
+                    return fSym != Word;
+                },
                 UseDefaults = true,
                 MatchingMethod = MatchingMethod.Unification
             }

--- a/tests/SIL.Machine.Tests/Rules/RuleTests.cs
+++ b/tests/SIL.Machine.Tests/Rules/RuleTests.cs
@@ -118,7 +118,14 @@ public class RuleTests : PhoneticTestsBase
             },
             input =>
                 input
-                    .Annotations.Single(ann => ((FeatureSymbol)ann.FeatureStruct.GetValue(Type)) == Word)
+                    .Annotations.Single(ann =>
+                    {
+                        FeatureSymbol f = SymbolicFeatureValue.GetFeatureSymbolFromFeatureStruct(
+                            ann.FeatureStruct,
+                            Type
+                        );
+                        return f == Word;
+                    })
                     .FeatureStruct.IsUnifiable(FeatureStruct.New(WordFeatSys).Symbol("verb").Value)
         );
 


### PR DESCRIPTION
This is a fix related to "L[T-22190 Hermit Crab adds wrong POSes to compound rules when there are more than 64 POSes](url)"

The problem is that Machine uses a ulong to represent the possible values of a feature.  This solution uses a BitArray instead of a ulong whenever there are more than sizeof(ulong) * 8 (=64) values.

The solution has a subclass of SymbolicFeatureValue called SymbolicFeatureValueBA which is used whenever there are more than 64 possible symbol values.  It adds a SymbolicFeatureValueFactory singleton class to create symbolic feature value objects.

The SymbolicFeatureValue class also now has a static method called GetFeatureSymbolFromFeatureStruct().  For reasons not clear to me, the static implicit operator SymbolicFeatureValue(FeatureSymbol symbol) method returns a null when invoked on a SymbolicFeatureValueBA oject.  This GetFeatureSymbolFromFeatureStruct() method is a way I found to make things work.  If there is a better way to do it, please let me know.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/322)
<!-- Reviewable:end -->
