### PR TITLE
Use default refs for empty non-scripture rows in NParallelTextCorpus

### DIFF
--- a/src/SIL.Machine/Corpora/NParallelTextCorpus.cs
+++ b/src/SIL.Machine/Corpora/NParallelTextCorpus.cs
@@ -302,7 +302,18 @@ namespace SIL.Machine.Corpora
                 if (rows[i] != null)
                 {
                     textId = textId ?? rows[i]?.TextId;
-                    refs[i] = CorrectVersification(rows[i].Ref == null ? defaultRefs : new object[] { rows[i].Ref }, i);
+                    if (Corpora[i].IsScripture())
+                    {
+                        refs[i] = CorrectVersification(
+                            rows[i].Ref == null ? defaultRefs : new object[] { rows[i].Ref },
+                            i
+                        );
+                    }
+                    else
+                    {
+                        refs[i] = defaultRefs;
+                    }
+
                     flags[i] = rows[i].Flags;
                 }
                 else
@@ -310,11 +321,11 @@ namespace SIL.Machine.Corpora
                     if (Corpora[i].IsScripture())
                         refs[i] = CorrectVersification(defaultRefs, i);
                     else
-                        refs[i] = new object[] { };
+                        refs[i] = defaultRefs;
                     flags[i] = forceInRange != null && forceInRange[i] ? TextRowFlags.InRange : TextRowFlags.None;
                 }
             }
-            refs = refs.Select(r => r ?? (new object[] { })).ToArray();
+            refs = refs.Select(r => r ?? defaultRefs).ToArray();
 
             yield return new NParallelTextRow(textId, refs)
             {

--- a/tests/SIL.Machine.Tests/Corpora/ParallelTextCorpusTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParallelTextCorpusTests.cs
@@ -695,12 +695,12 @@ public class ParallelTextCorpusTests
         ParallelTextRow[] rows = parallelCorpus.ToArray();
         Assert.That(rows.Length, Is.EqualTo(7));
         Assert.That(rows[1].SourceRefs, Is.EqualTo(new[] { 2 }));
-        Assert.That(rows[1].TargetRefs, Is.Empty);
+        Assert.That(rows[1].TargetRefs, Is.EqualTo(new[] { 2 }));
         Assert.That(rows[1].SourceSegment, Is.EqualTo("source segment 2 .".Split()));
         Assert.That(rows[1].TargetSegment, Is.Empty);
 
         Assert.That(rows[4].SourceRefs, Is.EqualTo(new[] { 5 }));
-        Assert.That(rows[4].TargetRefs, Is.Empty);
+        Assert.That(rows[4].TargetRefs, Is.EqualTo(new[] { 5 }));
         Assert.That(rows[4].SourceSegment, Is.EqualTo("source segment 5 .".Split()));
         Assert.That(rows[4].TargetSegment, Is.Empty);
     }


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/725

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/323)
<!-- Reviewable:end -->
