### PR TITLE
Use text element indices not string indices for PreviousCharacter

### DIFF
--- a/src/SIL.Machine/PunctuationAnalysis/QuotationMarkStringMatch.cs
+++ b/src/SIL.Machine/PunctuationAnalysis/QuotationMarkStringMatch.cs
@@ -75,7 +75,7 @@ namespace SIL.Machine.PunctuationAnalysis
                     if (previousSegment != null && !TextSegment.MarkerIsInPrecedingContext(UsfmMarkerType.Paragraph))
                     {
                         return new StringInfo(previousSegment.Text).SubstringByTextElements(
-                            previousSegment.Text.Length - 1,
+                            StringInfo.ParseCombiningCharacters(previousSegment.Text).Length - 1,
                             1
                         );
                     }

--- a/tests/SIL.Machine.Tests/PunctuationAnalysis/QuotationMarkStringMatchTests.cs
+++ b/tests/SIL.Machine.Tests/PunctuationAnalysis/QuotationMarkStringMatchTests.cs
@@ -188,13 +188,24 @@ public class QuotationMarkStringMatchTests
             0,
             1
         );
-        ;
+        Assert.IsNull(quotationMarkStringMatch.PreviousCharacter);
+
         quotationMarkStringMatch = new QuotationMarkStringMatch(
             new TextSegment.Builder().SetText("\u201c\u201d").Build(),
             1,
             2
         );
         Assert.That(quotationMarkStringMatch.PreviousCharacter, Is.EqualTo("“"));
+
+        quotationMarkStringMatch = new QuotationMarkStringMatch(
+            new TextSegment.Builder()
+                .SetText("\"उत्पत्ति पुस्तकले")
+                .SetPreviousSegment(new TextSegment.Builder().SetText("उत्पत्ति पुस्तकले").Build())
+                .Build(),
+            0,
+            1
+        );
+        Assert.That(quotationMarkStringMatch.PreviousCharacter, Is.EqualTo("ले"));
     }
 
     [Test]


### PR DESCRIPTION
Fixes the recent text element issue @pmachapman was seeing. (Is there an issue for that, Peter? I couldn't find it). Also, adds a test to cover it.

Related to https://github.com/sillsdev/machine/issues/324. 