### PR TITLE
Improve versification error detection

### DIFF
--- a/src/SIL.Machine/Corpora/UsfmVersificationErrorDetector.cs
+++ b/src/SIL.Machine/Corpora/UsfmVersificationErrorDetector.cs
@@ -104,7 +104,7 @@ namespace SIL.Machine.Corpora
                 // an exception with certain invalid verse data; use TryParse instead.
                 if (!VerseRef.TryParse($"{_bookNum} {_expectedChapter}:{_expectedVerse}", out VerseRef defaultVerseRef))
                 {
-                    return "";
+                    return DefaultVerse(_expectedChapter, _expectedVerse);
                 }
                 if (Type == UsfmVersificationErrorType.ExtraVerse)
                     return "";
@@ -144,10 +144,30 @@ namespace SIL.Machine.Corpora
                 return defaultVerseRef.ToString();
             }
         }
-        public string ActualVerseRef =>
-            _verseRef != null
-                ? _verseRef.Value.ToString()
-                : new VerseRef(_bookNum, _actualChapter, _actualVerse).ToString();
+        public string ActualVerseRef
+        {
+            get
+            {
+                if (_verseRef != null)
+                {
+                    return _verseRef.ToString();
+                }
+                else
+                {
+                    if (VerseRef.TryParse($"{_bookNum} {_actualChapter}:{_actualVerse}", out VerseRef actualVerseRef))
+                    {
+                        return actualVerseRef.ToString();
+                    }
+                }
+                return DefaultVerse(_actualChapter, _actualVerse);
+            }
+        }
+
+        private string DefaultVerse(int chapter, int verse)
+        {
+            string verseString = _actualVerse == -1 ? "" : verse.ToString();
+            return $"{Canon.BookNumberToId(_bookNum)} {chapter}:{verseString}";
+        }
     }
 
     public class UsfmVersificationErrorDetector : UsfmParserHandlerBase

--- a/tests/SIL.Machine.Tests/Corpora/ParatextProjectVersificationErrorTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParatextProjectVersificationErrorTests.cs
@@ -9,7 +9,7 @@ namespace SIL.Machine.Corpora;
 public class ParatextProjectQuoteConventionDetectorTests
 {
     [Test]
-    public void GetUsfmVersificationErrors_Noerrors()
+    public void GetUsfmVersificationErrors_NoErrors()
     {
         var env = new TestEnvironment(
             files: new Dictionary<string, string>()


### PR DESCRIPTION
* Make ActualVerseRef & ExpectedVerseRef more robust and helpful
* Fix test typo

This comes out of a problem John Nystrom experienced with a project. While I was in the code, I also made some other small tweaks.

This will need to be ported to machine.py.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/362)
<!-- Reviewable:end -->
