### PR TITLE
Add versification warnings for invalid chapter or verse numbers in USFM

### DIFF
--- a/src/SIL.Machine/Corpora/UsfmVersificationErrorDetector.cs
+++ b/src/SIL.Machine/Corpora/UsfmVersificationErrorDetector.cs
@@ -12,7 +12,9 @@ namespace SIL.Machine.Corpora
         ExtraVerse,
         InvalidVerseRange,
         MissingVerseSegment,
-        ExtraVerseSegment
+        ExtraVerseSegment,
+        InvalidChapterNumber,
+        InvalidVerseNumber
     }
 
     public class UsfmVersificationError
@@ -22,6 +24,7 @@ namespace SIL.Machine.Corpora
         private readonly int _expectedVerse;
         private readonly int _actualChapter;
         private readonly int _actualVerse;
+        private readonly string _actualValue;
         private VerseRef? _verseRef = null;
 
         public UsfmVersificationError(
@@ -41,6 +44,21 @@ namespace SIL.Machine.Corpora
             _actualVerse = actualVerse;
             _verseRef = verseRef;
             ProjectName = projectName;
+        }
+
+        public UsfmVersificationError(
+            int bookNum,
+            int expectedChapter,
+            string actualValue,
+            string projectName,
+            UsfmVersificationErrorType type
+        )
+        {
+            _bookNum = bookNum;
+            _expectedChapter = expectedChapter;
+            _actualValue = actualValue;
+            ProjectName = projectName;
+            Type = type;
         }
 
         public string ProjectName { get; private set; }
@@ -104,8 +122,14 @@ namespace SIL.Machine.Corpora
         {
             get
             {
-                if (Type == UsfmVersificationErrorType.ExtraVerse)
+                if (
+                    Type == UsfmVersificationErrorType.ExtraVerse
+                    || Type == UsfmVersificationErrorType.InvalidChapterNumber
+                    || Type == UsfmVersificationErrorType.InvalidVerseNumber
+                )
+                {
                     return "";
+                }
 
                 // We do not want to throw an exception here, and the VerseRef constructor can throw
                 // an exception with certain invalid verse data; use TryParse instead.
@@ -154,11 +178,20 @@ namespace SIL.Machine.Corpora
                 return defaultVerseRef.ToString();
             }
         }
+
         public string ActualVerseRef
         {
             get
             {
-                if (_verseRef != null)
+                if (Type == UsfmVersificationErrorType.InvalidChapterNumber)
+                {
+                    return $"{Canon.BookNumberToId(_bookNum)} {_actualValue}";
+                }
+                else if (Type == UsfmVersificationErrorType.InvalidVerseNumber)
+                {
+                    return $"{Canon.BookNumberToId(_bookNum)} {_expectedChapter}:{_actualValue}";
+                }
+                else if (_verseRef != null)
                 {
                     return _verseRef.ToString();
                 }
@@ -254,6 +287,22 @@ namespace SIL.Machine.Corpora
 
             _currentChapter = state.VerseRef.ChapterNum;
             _currentVerse = new VerseRef();
+
+            // See whether the chapter number is invalid
+            VerseRef verseRef = state.VerseRef.Clone();
+            verseRef.Chapter = number;
+            if (verseRef.ChapterNum == -1)
+            {
+                _errors.Add(
+                    new UsfmVersificationError(
+                        _currentBook,
+                        _currentChapter,
+                        number,
+                        _projectName,
+                        UsfmVersificationErrorType.InvalidChapterNumber
+                    )
+                );
+            }
         }
 
         public override void Verse(
@@ -264,6 +313,7 @@ namespace SIL.Machine.Corpora
             string pubNumber
         )
         {
+            bool verseInError = false;
             _currentVerse = state.VerseRef;
             if (_currentBook > 0 && Canon.IsCanonical(_currentBook) && _currentChapter > 0)
             {
@@ -277,7 +327,29 @@ namespace SIL.Machine.Corpora
                     _currentVerse
                 );
                 if (versificationError.CheckError())
+                {
                     _errors.Add(versificationError);
+                    verseInError = true;
+                }
+            }
+
+            if (!verseInError)
+            {
+                // See whether the verse number is invalid
+                VerseRef verseRef = _currentVerse.Clone();
+                verseRef.Verse = number;
+                if (verseRef.VerseNum == -1)
+                {
+                    _errors.Add(
+                        new UsfmVersificationError(
+                            _currentBook,
+                            _currentChapter,
+                            number,
+                            _projectName,
+                            UsfmVersificationErrorType.InvalidVerseNumber
+                        )
+                    );
+                }
             }
         }
     }

--- a/tests/SIL.Machine.Tests/Corpora/ParatextProjectVersificationErrorTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParatextProjectVersificationErrorTests.cs
@@ -397,6 +397,55 @@ public class ParatextProjectVersificationErrorDetectorTests
         Assert.That(errors[1].ActualVerseRef, Is.EqualTo("2JN 2:1"));
     }
 
+    [Test]
+    public void GetUsfmVersificationErrors_InvalidChapterNumber()
+    {
+        var env = new TestEnvironment(
+            files: new Dictionary<string, string>()
+            {
+                {
+                    "653JNTest.SFM",
+                    @"\id 3JN
+        \c 1.
+        "
+                }
+            }
+        );
+        IReadOnlyList<UsfmVersificationError> errors = env.GetUsfmVersificationErrors();
+        Assert.That(errors, Has.Count.EqualTo(2), JsonSerializer.Serialize(errors));
+        Assert.That(errors[0].Type, Is.EqualTo(UsfmVersificationErrorType.InvalidChapterNumber));
+        Assert.That(errors[1].Type, Is.EqualTo(UsfmVersificationErrorType.MissingChapter));
+        Assert.That(errors[0].ExpectedVerseRef, Is.Empty);
+        Assert.That(errors[1].ExpectedVerseRef, Is.EqualTo("3JN 1:15"));
+        Assert.That(errors[0].ActualVerseRef, Is.EqualTo("3JN 1."));
+        Assert.That(errors[1].ActualVerseRef, Is.EqualTo("3JN -1:0"));
+    }
+
+    [Test]
+    public void GetUsfmVersificationErrors_InvalidVerseNumber()
+    {
+        var env = new TestEnvironment(
+            files: new Dictionary<string, string>()
+            {
+                {
+                    "653JNTest.SFM",
+                    @"\id 3JN
+        \c 1
+        \v v1
+        "
+                }
+            }
+        );
+        IReadOnlyList<UsfmVersificationError> errors = env.GetUsfmVersificationErrors();
+        Assert.That(errors, Has.Count.EqualTo(2), JsonSerializer.Serialize(errors));
+        Assert.That(errors[0].Type, Is.EqualTo(UsfmVersificationErrorType.InvalidVerseNumber));
+        Assert.That(errors[1].Type, Is.EqualTo(UsfmVersificationErrorType.MissingVerse));
+        Assert.That(errors[0].ExpectedVerseRef, Is.Empty);
+        Assert.That(errors[1].ExpectedVerseRef, Is.EqualTo("3JN 1:15"));
+        Assert.That(errors[0].ActualVerseRef, Is.EqualTo("3JN 1:v1"));
+        Assert.That(errors[1].ActualVerseRef, Is.EqualTo("3JN 1:0"));
+    }
+
     private class TestEnvironment(ParatextProjectSettings? settings = null, Dictionary<string, string>? files = null)
     {
         public ParatextProjectVersificationErrorDetectorBase Detector { get; } =


### PR DESCRIPTION
Fixes: #372

Example USFM:

```
\id MAN
\c 1.
\v v1 Verse 1
```

Example warnings:

```
warnings: [
  "USFM versification error in project TEA, expected verse “”, actual verse “MAN 1.”, mismatch type InvalidChapterNumber (parallel corpus 6983d7b5415e5f0ee3585264, monolingual corpus 6983d7b5415e5f0ee3585260)",
  "USFM versification error in project TEA, expected verse “”, actual verse “MAN -1:v1”, mismatch type InvalidVerseNumber (parallel corpus 6983d7b5415e5f0ee3585264, monolingual corpus 6983d7b5415e5f0ee3585260)",
]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/381)
<!-- Reviewable:end -->
