### PR TITLE
Handle empty TranslationInfo tag properly when parsing Settings.xml

### DIFF
--- a/src/SIL.Machine/Corpora/ParatextProjectSettingsParserBase.cs
+++ b/src/SIL.Machine/Corpora/ParatextProjectSettingsParserBase.cs
@@ -123,12 +123,12 @@ namespace SIL.Machine.Corpora
             string translationType = "Standard";
             string parentName = null;
             string parentGuid = null;
-            if (translationInfoSetting != null)
+            string[] translationInfoSettingParts = translationInfoSetting?.Split(':');
+            if (translationInfoSettingParts?.Length == 3)
             {
-                string[] translationInfoSettingParts = translationInfoSetting.Split(':');
                 translationType = translationInfoSettingParts[0];
-                parentName = translationInfoSettingParts[1] != "" ? translationInfoSettingParts[1] : null;
-                parentGuid = translationInfoSettingParts[2] != "" ? translationInfoSettingParts[2] : null;
+                parentName = translationInfoSettingParts[1] != string.Empty ? translationInfoSettingParts[1] : null;
+                parentGuid = translationInfoSettingParts[2] != string.Empty ? translationInfoSettingParts[2] : null;
             }
 
             var settings = new ParatextProjectSettings(

--- a/tests/SIL.Machine.Tests/Corpora/MemoryParatextProjectFileHandler.cs
+++ b/tests/SIL.Machine.Tests/Corpora/MemoryParatextProjectFileHandler.cs
@@ -9,6 +9,8 @@ public class MemoryParatextProjectFileHandler(IDictionary<string, string>? files
 
     public UsfmStylesheet CreateStylesheet(string fileName)
     {
+        if (fileName is "usfm.sty" or "usfm_sb.sty")
+            return new UsfmStylesheet(fileName);
         throw new NotImplementedException();
     }
 

--- a/tests/SIL.Machine.Tests/Corpora/MemoryParatextProjectSettingsParser.cs
+++ b/tests/SIL.Machine.Tests/Corpora/MemoryParatextProjectSettingsParser.cs
@@ -1,0 +1,6 @@
+namespace SIL.Machine.Corpora;
+
+public class MemoryParatextProjectSettingsParser(
+    IDictionary<string, string>? files = null,
+    ParatextProjectSettings? parentSettings = null
+) : ParatextProjectSettingsParserBase(new MemoryParatextProjectFileHandler(files), parentSettings);

--- a/tests/SIL.Machine.Tests/Corpora/ParatextProjectSettingsParserTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/ParatextProjectSettingsParserTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+
+namespace SIL.Machine.Corpora;
+
+[TestFixture]
+public class ParatextProjectSettingsParserTests
+{
+    [Test]
+    public void TranslationInfoEmptyValues()
+    {
+        ParatextProjectSettings settings = CreateSettings("<TranslationInfo></TranslationInfo>");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(settings.TranslationType, Is.EqualTo("Standard"));
+            Assert.That(settings.ParentName, Is.Null);
+            Assert.That(settings.ParentGuid, Is.Null);
+        }
+    }
+
+    [Test]
+    public void TranslationInfoNoParentSpecified()
+    {
+        ParatextProjectSettings settings = CreateSettings("<TranslationInfo>BackTranslation::</TranslationInfo>");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(settings.TranslationType, Is.EqualTo("BackTranslation"));
+            Assert.That(settings.ParentName, Is.Null);
+            Assert.That(settings.ParentGuid, Is.Null);
+        }
+    }
+
+    [Test]
+    public void TranslationInfoSpecified()
+    {
+        ParatextProjectSettings settings = CreateSettings(
+            "<TranslationInfo>Daughter:DEF:22222222222222222222222222222222</TranslationInfo>"
+        );
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(settings.TranslationType, Is.EqualTo("Daughter"));
+            Assert.That(settings.ParentName, Is.EqualTo("DEF"));
+            Assert.That(settings.ParentGuid, Is.EqualTo("22222222222222222222222222222222"));
+        }
+    }
+
+    private static ParatextProjectSettings CreateSettings(string additionalSettingsXml = "")
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["Settings.xml"] =
+                "<ScriptureText>"
+                + "<Guid>11111111111111111111111111111111</Guid>"
+                + "<Name>ABC</Name>"
+                + "<FullName>Test Project</FullName>"
+                + additionalSettingsXml
+                + "</ScriptureText>",
+        };
+        var parser = new MemoryParatextProjectSettingsParser(files);
+        return parser.Parse();
+    }
+}


### PR DESCRIPTION
Fixes #401.

I tested by modifying the Settings.xml file manually. If you think this should have its own test, we will need another test project in the file system, as none of the file system calls go through an abstraction layer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/402)
<!-- Reviewable:end -->
