### PR TITLE
Fix LT-22480: Merge rule bug

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/NarrowSynthesisRewriteSubruleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/NarrowSynthesisRewriteSubruleSpec.cs
@@ -42,9 +42,16 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             }
 
             ShapeNode[] nodes = targetMatch.Input.Shape.GetNodes(range).ToArray();
-            for (int i = 0; i < _targetCount; i++)
+            int deleted = 0;
+            for (int i = 0; i < nodes.Length; i++)
+            {
+                if (nodes[i].IsDeleted())
+                    continue;
                 nodes[i].SetDeleted(true);
-
+                deleted++;
+                if (deleted == _targetCount)
+                    break;
+            }
             MarkSuccessfulApply(targetMatch.Input);
         }
     }


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22480.  When deleting nodes, it should skip over the nodes that have already been deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/403)
<!-- Reviewable:end -->
