### PR TITLE
Add eflomal word aligner: Bayesian IBM1→HMM→fertility with N parallel Gibbs chains

### DIFF
--- a/src/SIL.Machine.Tool/AlignmentModelCommandSpec.cs
+++ b/src/SIL.Machine.Tool/AlignmentModelCommandSpec.cs
@@ -176,7 +176,16 @@ public class AlignmentModelCommandSpec : ICommandSpec
         SetThotParameter(parameters, thotParameters, "ibm3-iters", p => p.Ibm3IterationCount);
         SetThotParameter(parameters, thotParameters, "ibm4-iters", p => p.Ibm4IterationCount);
         SetThotParameter(parameters, thotParameters, "eflomal-iters", p => p.EflomalIterationCount);
+        SetThotParameter(parameters, thotParameters, "eflomal-ibm1-iters", p => p.EflomalIbm1IterationCount);
+        SetThotParameter(parameters, thotParameters, "eflomal-hmm-iters", p => p.EflomalHmmIterationCount);
+        SetThotParameter(parameters, thotParameters, "eflomal-fert-iters", p => p.EflomalFertilityIterationCount);
         SetThotParameter(parameters, thotParameters, "eflomal-samplers", p => p.EflomalNumSamplers);
+        SetThotParameter(parameters, thotParameters, "eflomal-lex-alpha", p => p.EflomalLexAlpha);
+        SetThotParameter(parameters, thotParameters, "eflomal-null-alpha", p => p.EflomalNullAlpha);
+        SetThotParameter(parameters, thotParameters, "eflomal-jump-alpha", p => p.EflomalJumpAlpha);
+        SetThotParameter(parameters, thotParameters, "eflomal-fert-alpha", p => p.EflomalFertilityAlpha);
+        SetThotParameter(parameters, thotParameters, "eflomal-null-prob", p => p.EflomalNullProb);
+        SetThotParameter(parameters, thotParameters, "eflomal-jump-window", p => p.EflomalJumpWindow);
         SetThotParameter(parameters, thotParameters, "var-bayes", p => p.VariationalBayes);
         SetThotParameter(parameters, thotParameters, "fa-p0", p => p.FastAlignP0);
         SetThotParameter(parameters, thotParameters, "hmm-p0", p => p.HmmP0);

--- a/src/SIL.Machine.Tool/AlignmentModelCommandSpec.cs
+++ b/src/SIL.Machine.Tool/AlignmentModelCommandSpec.cs
@@ -37,7 +37,7 @@ public class AlignmentModelCommandSpec : ICommandSpec
         _modelArgument = command.Argument("MODEL_PATH", "The word alignment model.").IsRequired();
         _modelTypeOption = command.Option(
             "-mt|--model-type <MODEL_TYPE>",
-            $"The word alignment model type.\nTypes: \"{ToolHelpers.Hmm}\" (default), \"{ToolHelpers.Ibm1}\", \"{ToolHelpers.Ibm2}\", \"{ToolHelpers.Ibm3}\", \"{ToolHelpers.Ibm4}\", \"{ToolHelpers.FastAlign}\".",
+            $"The word alignment model type.\nTypes: \"{ToolHelpers.Hmm}\" (default), \"{ToolHelpers.Ibm1}\", \"{ToolHelpers.Ibm2}\", \"{ToolHelpers.Ibm3}\", \"{ToolHelpers.Ibm4}\", \"{ToolHelpers.FastAlign}\", \"{ToolHelpers.Eflomal}\".",
             CommandOptionType.SingleValue
         );
         _pluginOption = command.Option(
@@ -175,6 +175,8 @@ public class AlignmentModelCommandSpec : ICommandSpec
         SetThotParameter(parameters, thotParameters, "hmm-iters", p => p.HmmIterationCount);
         SetThotParameter(parameters, thotParameters, "ibm3-iters", p => p.Ibm3IterationCount);
         SetThotParameter(parameters, thotParameters, "ibm4-iters", p => p.Ibm4IterationCount);
+        SetThotParameter(parameters, thotParameters, "eflomal-iters", p => p.EflomalIterationCount);
+        SetThotParameter(parameters, thotParameters, "eflomal-samplers", p => p.EflomalNumSamplers);
         SetThotParameter(parameters, thotParameters, "var-bayes", p => p.VariationalBayes);
         SetThotParameter(parameters, thotParameters, "fa-p0", p => p.FastAlignP0);
         SetThotParameter(parameters, thotParameters, "hmm-p0", p => p.HmmP0);
@@ -235,6 +237,7 @@ public class AlignmentModelCommandSpec : ICommandSpec
             ToolHelpers.FastAlign,
             ToolHelpers.Ibm3,
             ToolHelpers.Ibm4,
+            ToolHelpers.Eflomal,
         };
         validTypes.UnionWith(pluginTypes);
         return string.IsNullOrEmpty(value) || validTypes.Contains(value);

--- a/src/SIL.Machine.Tool/AlignmentModelCommandSpec.cs
+++ b/src/SIL.Machine.Tool/AlignmentModelCommandSpec.cs
@@ -175,16 +175,16 @@ public class AlignmentModelCommandSpec : ICommandSpec
         SetThotParameter(parameters, thotParameters, "hmm-iters", p => p.HmmIterationCount);
         SetThotParameter(parameters, thotParameters, "ibm3-iters", p => p.Ibm3IterationCount);
         SetThotParameter(parameters, thotParameters, "ibm4-iters", p => p.Ibm4IterationCount);
-        SetThotParameter(parameters, thotParameters, "eflomal-iters", p => p.EflomalIterationCount);
-        SetThotParameter(parameters, thotParameters, "eflomal-ibm1-iters", p => p.EflomalIbm1IterationCount);
-        SetThotParameter(parameters, thotParameters, "eflomal-hmm-iters", p => p.EflomalHmmIterationCount);
-        SetThotParameter(parameters, thotParameters, "eflomal-fert-iters", p => p.EflomalFertilityIterationCount);
+        // Eflomal reuses the IBM1/HMM/IBM3 iteration counts above for its IBM1->HMM->fertility
+        // schedule; when none are given it derives the schedule automatically from the corpus.
         SetThotParameter(parameters, thotParameters, "eflomal-samplers", p => p.EflomalNumSamplers);
+        SetThotParameter(parameters, thotParameters, "eflomal-deterministic", p => p.EflomalDeterministic);
+        SetThotParameter(parameters, thotParameters, "eflomal-seed", p => p.EflomalSeed);
+        SetThotParameter(parameters, thotParameters, "eflomal-lex-norm", p => p.EflomalLexNorm);
         SetThotParameter(parameters, thotParameters, "eflomal-lex-alpha", p => p.EflomalLexAlpha);
-        SetThotParameter(parameters, thotParameters, "eflomal-null-alpha", p => p.EflomalNullAlpha);
         SetThotParameter(parameters, thotParameters, "eflomal-jump-alpha", p => p.EflomalJumpAlpha);
         SetThotParameter(parameters, thotParameters, "eflomal-fert-alpha", p => p.EflomalFertilityAlpha);
-        SetThotParameter(parameters, thotParameters, "eflomal-null-prob", p => p.EflomalNullProb);
+        SetThotParameter(parameters, thotParameters, "eflomal-p0", p => p.EflomalP0);
         SetThotParameter(parameters, thotParameters, "eflomal-jump-window", p => p.EflomalJumpWindow);
         SetThotParameter(parameters, thotParameters, "var-bayes", p => p.VariationalBayes);
         SetThotParameter(parameters, thotParameters, "fa-p0", p => p.FastAlignP0);

--- a/src/SIL.Machine.Tool/ToolHelpers.cs
+++ b/src/SIL.Machine.Tool/ToolHelpers.cs
@@ -20,6 +20,7 @@ internal static class ToolHelpers
     public const string Hmm = "hmm";
     public const string Ibm3 = "ibm3";
     public const string Ibm4 = "ibm4";
+    public const string Eflomal = "eflomal";
 
     public const string Och = "och";
     public const string Union = "union";

--- a/src/SIL.Machine.Translation.Thot/SIL.Machine.Translation.Thot.csproj
+++ b/src/SIL.Machine.Translation.Thot/SIL.Machine.Translation.Thot.csproj
@@ -12,7 +12,7 @@
 	<Import Project="../AssemblyInfo.props" />
 
 	<ItemGroup>
-		<PackageReference Include="Thot" Version="3.4.9" />
+		<PackageReference Include="Thot" Version="3.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SIL.Machine.Translation.Thot/Thot.cs
+++ b/src/SIL.Machine.Translation.Thot/Thot.cs
@@ -179,10 +179,25 @@ namespace SIL.Machine.Translation.Thot
         public static extern bool swAlignModel_getVariationalBayes(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalSeed(IntPtr swAlignModelHandle, uint seed);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint swAlignModel_getEflomalSeed(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setEflomalNumSamplers(IntPtr swAlignModelHandle, int numSamplers);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern int swAlignModel_getEflomalNumSamplers(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalDeterministic(
+            IntPtr swAlignModelHandle,
+            bool deterministic
+        );
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool swAlignModel_getEflomalDeterministic(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setEflomalIterations(
@@ -193,25 +208,37 @@ namespace SIL.Machine.Translation.Thot
         );
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int swAlignModel_getEflomalIbm1Iters(IntPtr swAlignModelHandle);
+        public static extern int swAlignModel_getEflomalIbm1Iterations(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int swAlignModel_getEflomalHmmIters(IntPtr swAlignModelHandle);
+        public static extern int swAlignModel_getEflomalHmmIterations(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int swAlignModel_getEflomalFertilityIters(IntPtr swAlignModelHandle);
+        public static extern int swAlignModel_getEflomalFertilityIterations(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int swAlignModel_getEflomalScheduledIterations(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalAutoIterations(
+            IntPtr swAlignModelHandle,
+            bool autoIterations
+        );
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool swAlignModel_getEflomalAutoIterations(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalLexNorm(IntPtr swAlignModelHandle, bool lexNorm);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool swAlignModel_getEflomalLexNorm(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setEflomalAlphaLex(IntPtr swAlignModelHandle, double alphaLex);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern double swAlignModel_getEflomalAlphaLex(IntPtr swAlignModelHandle);
-
-        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void swAlignModel_setEflomalAlphaNull(IntPtr swAlignModelHandle, double alphaNull);
-
-        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern double swAlignModel_getEflomalAlphaNull(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setEflomalAlphaJump(IntPtr swAlignModelHandle, double alphaJump);
@@ -229,10 +256,10 @@ namespace SIL.Machine.Translation.Thot
         public static extern double swAlignModel_getEflomalAlphaFertility(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void swAlignModel_setEflomalNullProb(IntPtr swAlignModelHandle, double nullProb);
+        public static extern void swAlignModel_setEflomalP0(IntPtr swAlignModelHandle, double p0);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern double swAlignModel_getEflomalNullProb(IntPtr swAlignModelHandle);
+        public static extern double swAlignModel_getEflomalP0(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setEflomalJumpWindow(IntPtr swAlignModelHandle, int jumpWindow);
@@ -399,7 +426,24 @@ namespace SIL.Machine.Translation.Thot
         );
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getFastAlignAlignmentProbability(
+            IntPtr swAlignModelHandle,
+            uint j,
+            uint sLen,
+            uint tLen,
+            uint i
+        );
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern double swAlignModel_getHmmAlignmentProbability(
+            IntPtr swAlignModelHandle,
+            uint prevI,
+            uint sLen,
+            uint i
+        );
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getEflomalAlignmentProbability(
             IntPtr swAlignModelHandle,
             uint prevI,
             uint sLen,

--- a/src/SIL.Machine.Translation.Thot/Thot.cs
+++ b/src/SIL.Machine.Translation.Thot/Thot.cs
@@ -22,6 +22,7 @@ namespace SIL.Machine.Translation.Thot
             IncrIbm1 = 6,
             IncrIbm2 = 7,
             IncrHmm = 8,
+            Eflomal = 9,
         }
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
@@ -176,6 +177,12 @@ namespace SIL.Machine.Translation.Thot
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool swAlignModel_getVariationalBayes(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalNumSamplers(IntPtr swAlignModelHandle, int numSamplers);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int swAlignModel_getEflomalNumSamplers(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setFastAlignP0(IntPtr swAlignModelHandle, double p0);
@@ -684,6 +691,8 @@ namespace SIL.Machine.Translation.Thot
                     return AlignmentModelType.Ibm3;
                 case ThotWordAlignmentModelType.Ibm4:
                     return AlignmentModelType.Ibm4;
+                case ThotWordAlignmentModelType.Eflomal:
+                    return AlignmentModelType.Eflomal;
             }
             throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ThotWordAlignmentModelType));
         }

--- a/src/SIL.Machine.Translation.Thot/Thot.cs
+++ b/src/SIL.Machine.Translation.Thot/Thot.cs
@@ -191,10 +191,7 @@ namespace SIL.Machine.Translation.Thot
         public static extern int swAlignModel_getEflomalNumSamplers(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void swAlignModel_setEflomalDeterministic(
-            IntPtr swAlignModelHandle,
-            bool deterministic
-        );
+        public static extern void swAlignModel_setEflomalDeterministic(IntPtr swAlignModelHandle, bool deterministic);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool swAlignModel_getEflomalDeterministic(IntPtr swAlignModelHandle);
@@ -220,10 +217,7 @@ namespace SIL.Machine.Translation.Thot
         public static extern int swAlignModel_getEflomalScheduledIterations(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void swAlignModel_setEflomalAutoIterations(
-            IntPtr swAlignModelHandle,
-            bool autoIterations
-        );
+        public static extern void swAlignModel_setEflomalAutoIterations(IntPtr swAlignModelHandle, bool autoIterations);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool swAlignModel_getEflomalAutoIterations(IntPtr swAlignModelHandle);

--- a/src/SIL.Machine.Translation.Thot/Thot.cs
+++ b/src/SIL.Machine.Translation.Thot/Thot.cs
@@ -185,6 +185,62 @@ namespace SIL.Machine.Translation.Thot
         public static extern int swAlignModel_getEflomalNumSamplers(IntPtr swAlignModelHandle);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalIterations(
+            IntPtr swAlignModelHandle,
+            int ibm1Iters,
+            int hmmIters,
+            int fertilityIters
+        );
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int swAlignModel_getEflomalIbm1Iters(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int swAlignModel_getEflomalHmmIters(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int swAlignModel_getEflomalFertilityIters(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalAlphaLex(IntPtr swAlignModelHandle, double alphaLex);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getEflomalAlphaLex(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalAlphaNull(IntPtr swAlignModelHandle, double alphaNull);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getEflomalAlphaNull(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalAlphaJump(IntPtr swAlignModelHandle, double alphaJump);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getEflomalAlphaJump(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalAlphaFertility(
+            IntPtr swAlignModelHandle,
+            double alphaFertility
+        );
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getEflomalAlphaFertility(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalNullProb(IntPtr swAlignModelHandle, double nullProb);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern double swAlignModel_getEflomalNullProb(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void swAlignModel_setEflomalJumpWindow(IntPtr swAlignModelHandle, int jumpWindow);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int swAlignModel_getEflomalJumpWindow(IntPtr swAlignModelHandle);
+
+        [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]
         public static extern void swAlignModel_setFastAlignP0(IntPtr swAlignModelHandle, double p0);
 
         [DllImport("thot", CallingConvention = CallingConvention.Cdecl)]

--- a/src/SIL.Machine.Translation.Thot/ThotEflomalWordAlignmentModel.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotEflomalWordAlignmentModel.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using SIL.Machine.Corpora;
+
+namespace SIL.Machine.Translation.Thot
+{
+    public class ThotEflomalWordAlignmentModel : ThotWordAlignmentModel
+    {
+        public ThotEflomalWordAlignmentModel() { }
+
+        public ThotEflomalWordAlignmentModel(string prefFileName, bool createNew = false)
+            : base(prefFileName, createNew) { }
+
+        public override ThotWordAlignmentModelType Type => ThotWordAlignmentModelType.Eflomal;
+
+        public override void ComputeAlignedWordPairScores(
+            IReadOnlyList<string> sourceSegment,
+            IReadOnlyList<string> targetSegment,
+            IReadOnlyCollection<AlignedWordPair> wordPairs
+        )
+        {
+            foreach (AlignedWordPair wordPair in wordPairs)
+            {
+                if (wordPair.TargetIndex == -1)
+                {
+                    wordPair.TranslationScore = 0;
+                    wordPair.AlignmentScore = 0;
+                }
+                else
+                {
+                    string sourceWord = wordPair.SourceIndex == -1 ? null : sourceSegment[wordPair.SourceIndex];
+                    string targetWord = targetSegment[wordPair.TargetIndex];
+                    wordPair.TranslationScore = GetTranslationProbability(sourceWord, targetWord);
+                    wordPair.AlignmentScore = 1.0;
+                }
+            }
+        }
+    }
+}

--- a/src/SIL.Machine.Translation.Thot/ThotEflomalWordAlignmentModel.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotEflomalWordAlignmentModel.cs
@@ -1,9 +1,6 @@
-using System.Collections.Generic;
-using SIL.Machine.Corpora;
-
 namespace SIL.Machine.Translation.Thot
 {
-    public class ThotEflomalWordAlignmentModel : ThotWordAlignmentModel
+    public class ThotEflomalWordAlignmentModel : ThotHmmWordAlignmentModelBase
     {
         public ThotEflomalWordAlignmentModel() { }
 
@@ -12,27 +9,17 @@ namespace SIL.Machine.Translation.Thot
 
         public override ThotWordAlignmentModelType Type => ThotWordAlignmentModelType.Eflomal;
 
-        public override void ComputeAlignedWordPairScores(
-            IReadOnlyList<string> sourceSegment,
-            IReadOnlyList<string> targetSegment,
-            IReadOnlyCollection<AlignedWordPair> wordPairs
-        )
+        public override double GetAlignmentProbability(int sourceLen, int prevSourceIndex, int sourceIndex)
         {
-            foreach (AlignedWordPair wordPair in wordPairs)
-            {
-                if (wordPair.TargetIndex == -1)
-                {
-                    wordPair.TranslationScore = 0;
-                    wordPair.AlignmentScore = 0;
-                }
-                else
-                {
-                    string sourceWord = wordPair.SourceIndex == -1 ? null : sourceSegment[wordPair.SourceIndex];
-                    string targetWord = targetSegment[wordPair.TargetIndex];
-                    wordPair.TranslationScore = GetTranslationProbability(sourceWord, targetWord);
-                    wordPair.AlignmentScore = 1.0;
-                }
-            }
+            CheckDisposed();
+
+            // add 1 to convert the specified indices to Thot position indices, which are 1-based
+            return Thot.swAlignModel_getEflomalAlignmentProbability(
+                Handle,
+                (uint)(prevSourceIndex + 1),
+                (uint)sourceLen,
+                (uint)(sourceIndex + 1)
+            );
         }
     }
 }

--- a/src/SIL.Machine.Translation.Thot/ThotFastAlignWordAlignmentModel.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotFastAlignWordAlignmentModel.cs
@@ -19,7 +19,7 @@ namespace SIL.Machine.Translation.Thot
                 return 0;
 
             // add 1 to convert the specified indices to Thot position indices, which are 1-based
-            return Thot.swAlignModel_getIbm2AlignmentProbability(
+            return Thot.swAlignModel_getFastAlignAlignmentProbability(
                 Handle,
                 (uint)(targetIndex + 1),
                 (uint)sourceLen,

--- a/src/SIL.Machine.Translation.Thot/ThotHmmWordAlignmentModel.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotHmmWordAlignmentModel.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using SIL.Machine.Corpora;
-
 namespace SIL.Machine.Translation.Thot
 {
-    public class ThotHmmWordAlignmentModel : ThotIbm1WordAlignmentModel, IHmmWordAlignmentModel
+    public class ThotHmmWordAlignmentModel : ThotHmmWordAlignmentModelBase
     {
         public ThotHmmWordAlignmentModel() { }
 
@@ -13,12 +9,7 @@ namespace SIL.Machine.Translation.Thot
 
         public override ThotWordAlignmentModelType Type => ThotWordAlignmentModelType.Hmm;
 
-        /// <summary>
-        /// Gets the alignment probability from the HMM single word alignment model. Use -1 for unaligned indices that
-        /// occur before the first aligned index. Other unaligned indices are indicated by adding the source length to
-        /// the previously aligned index.
-        /// </summary>
-        public double GetAlignmentProbability(int sourceLen, int prevSourceIndex, int sourceIndex)
+        public override double GetAlignmentProbability(int sourceLen, int prevSourceIndex, int sourceIndex)
         {
             CheckDisposed();
 
@@ -29,72 +20,6 @@ namespace SIL.Machine.Translation.Thot
                 (uint)sourceLen,
                 (uint)(sourceIndex + 1)
             );
-        }
-
-        public override void ComputeAlignedWordPairScores(
-            IReadOnlyList<string> sourceSegment,
-            IReadOnlyList<string> targetSegment,
-            IReadOnlyCollection<AlignedWordPair> wordPairs
-        )
-        {
-            int[] sourceIndices = Enumerable.Repeat(-2, targetSegment.Count).ToArray();
-            int prevSourceIndex = -1;
-            var alignedTargetIndices = new HashSet<int>();
-            foreach (AlignedWordPair wordPair in wordPairs.OrderBy(wp => wp.TargetIndex))
-            {
-                if (wordPair.TargetIndex == -1)
-                    continue;
-                if (sourceIndices[wordPair.TargetIndex] == -2)
-                {
-                    int sourceIndex = wordPair.SourceIndex;
-                    if (sourceIndex == -1)
-                        sourceIndex = prevSourceIndex == -1 ? -1 : sourceSegment.Count + prevSourceIndex;
-                    sourceIndices[wordPair.TargetIndex] = sourceIndex;
-                    prevSourceIndex = sourceIndex;
-                }
-                alignedTargetIndices.Add(wordPair.TargetIndex);
-            }
-
-            if (alignedTargetIndices.Count < targetSegment.Count)
-            {
-                // there are target words that are aligned to NULL, so fill in the correct source index
-                prevSourceIndex = -1;
-                for (int j = 0; j < targetSegment.Count; j++)
-                {
-                    if (sourceIndices[j] == -2)
-                    {
-                        int sourceIndex = prevSourceIndex == -1 ? -1 : sourceSegment.Count + prevSourceIndex;
-                        sourceIndices[j] = sourceIndex;
-                        prevSourceIndex = sourceIndex;
-                    }
-                    else
-                    {
-                        prevSourceIndex = sourceIndices[j];
-                    }
-                }
-            }
-
-            foreach (AlignedWordPair wordPair in wordPairs)
-            {
-                if (wordPair.TargetIndex == -1)
-                {
-                    wordPair.TranslationScore = 0;
-                    wordPair.AlignmentScore = 0;
-                }
-                else
-                {
-                    string sourceWord = wordPair.SourceIndex == -1 ? null : sourceSegment[wordPair.SourceIndex];
-                    string targetWord = targetSegment[wordPair.TargetIndex];
-                    wordPair.TranslationScore = GetTranslationProbability(sourceWord, targetWord);
-                    prevSourceIndex = wordPair.TargetIndex == 0 ? -1 : sourceIndices[wordPair.TargetIndex - 1];
-                    int sourceIndex = sourceIndices[wordPair.TargetIndex];
-                    wordPair.AlignmentScore = GetAlignmentProbability(
-                        sourceSegment.Count,
-                        prevSourceIndex,
-                        sourceIndex
-                    );
-                }
-            }
         }
     }
 }

--- a/src/SIL.Machine.Translation.Thot/ThotHmmWordAlignmentModelBase.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotHmmWordAlignmentModelBase.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using SIL.Machine.Corpora;
+
+namespace SIL.Machine.Translation.Thot
+{
+    public abstract class ThotHmmWordAlignmentModelBase : ThotIbm1WordAlignmentModel, IHmmWordAlignmentModel
+    {
+        protected ThotHmmWordAlignmentModelBase() { }
+
+        protected ThotHmmWordAlignmentModelBase(string prefFileName, bool createNew = false)
+            : base(prefFileName, createNew) { }
+
+        /// <summary>
+        /// Gets the alignment probability from the HMM-based single word alignment model. Use -1 for unaligned indices
+        /// that occur before the first aligned index. Other unaligned indices are indicated by adding the source length
+        /// to the previously aligned index.
+        /// </summary>
+        public abstract double GetAlignmentProbability(int sourceLen, int prevSourceIndex, int sourceIndex);
+
+        public override void ComputeAlignedWordPairScores(
+            IReadOnlyList<string> sourceSegment,
+            IReadOnlyList<string> targetSegment,
+            IReadOnlyCollection<AlignedWordPair> wordPairs
+        )
+        {
+            int[] sourceIndices = Enumerable.Repeat(-2, targetSegment.Count).ToArray();
+            int prevSourceIndex = -1;
+            var alignedTargetIndices = new HashSet<int>();
+            foreach (AlignedWordPair wordPair in wordPairs.OrderBy(wp => wp.TargetIndex))
+            {
+                if (wordPair.TargetIndex == -1)
+                    continue;
+                if (sourceIndices[wordPair.TargetIndex] == -2)
+                {
+                    int sourceIndex = wordPair.SourceIndex;
+                    if (sourceIndex == -1)
+                        sourceIndex = prevSourceIndex == -1 ? -1 : sourceSegment.Count + prevSourceIndex;
+                    sourceIndices[wordPair.TargetIndex] = sourceIndex;
+                    prevSourceIndex = sourceIndex;
+                }
+                alignedTargetIndices.Add(wordPair.TargetIndex);
+            }
+
+            if (alignedTargetIndices.Count < targetSegment.Count)
+            {
+                // there are target words that are aligned to NULL, so fill in the correct source index
+                prevSourceIndex = -1;
+                for (int j = 0; j < targetSegment.Count; j++)
+                {
+                    if (sourceIndices[j] == -2)
+                    {
+                        int sourceIndex = prevSourceIndex == -1 ? -1 : sourceSegment.Count + prevSourceIndex;
+                        sourceIndices[j] = sourceIndex;
+                        prevSourceIndex = sourceIndex;
+                    }
+                    else
+                    {
+                        prevSourceIndex = sourceIndices[j];
+                    }
+                }
+            }
+
+            foreach (AlignedWordPair wordPair in wordPairs)
+            {
+                if (wordPair.TargetIndex == -1)
+                {
+                    wordPair.TranslationScore = 0;
+                    wordPair.AlignmentScore = 0;
+                }
+                else
+                {
+                    string sourceWord = wordPair.SourceIndex == -1 ? null : sourceSegment[wordPair.SourceIndex];
+                    string targetWord = targetSegment[wordPair.TargetIndex];
+                    wordPair.TranslationScore = GetTranslationProbability(sourceWord, targetWord);
+                    prevSourceIndex = wordPair.TargetIndex == 0 ? -1 : sourceIndices[wordPair.TargetIndex - 1];
+                    int sourceIndex = sourceIndices[wordPair.TargetIndex];
+                    wordPair.AlignmentScore = GetAlignmentProbability(
+                        sourceSegment.Count,
+                        prevSourceIndex,
+                        sourceIndex
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModel.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModel.cs
@@ -31,6 +31,8 @@ namespace SIL.Machine.Translation.Thot
                     return new ThotIbm3WordAlignmentModel();
                 case ThotWordAlignmentModelType.Ibm4:
                     return new ThotIbm4WordAlignmentModel();
+                case ThotWordAlignmentModelType.Eflomal:
+                    return new ThotEflomalWordAlignmentModel();
             }
             throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ThotWordAlignmentModelType));
         }

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
@@ -77,6 +77,31 @@ namespace SIL.Machine.Translation.Thot
                     }
                     catch (EntryPointNotFoundException) { }
                 }
+                if (
+                    parameters.EflomalIbm1IterationCount.HasValue
+                    || parameters.EflomalHmmIterationCount.HasValue
+                    || parameters.EflomalFertilityIterationCount.HasValue
+                )
+                {
+                    Thot.swAlignModel_setEflomalIterations(
+                        eflomal,
+                        parameters.GetEflomalIbm1IterationCount(),
+                        parameters.GetEflomalHmmIterationCount(),
+                        parameters.GetEflomalFertilityIterationCount()
+                    );
+                }
+                if (parameters.EflomalLexAlpha.HasValue)
+                    Thot.swAlignModel_setEflomalAlphaLex(eflomal, parameters.EflomalLexAlpha.Value);
+                if (parameters.EflomalNullAlpha.HasValue)
+                    Thot.swAlignModel_setEflomalAlphaNull(eflomal, parameters.EflomalNullAlpha.Value);
+                if (parameters.EflomalJumpAlpha.HasValue)
+                    Thot.swAlignModel_setEflomalAlphaJump(eflomal, parameters.EflomalJumpAlpha.Value);
+                if (parameters.EflomalFertilityAlpha.HasValue)
+                    Thot.swAlignModel_setEflomalAlphaFertility(eflomal, parameters.EflomalFertilityAlpha.Value);
+                if (parameters.EflomalNullProb.HasValue)
+                    Thot.swAlignModel_setEflomalNullProb(eflomal, parameters.EflomalNullProb.Value);
+                if (parameters.EflomalJumpWindow.HasValue)
+                    Thot.swAlignModel_setEflomalJumpWindow(eflomal, parameters.EflomalJumpWindow.Value);
                 _models.Add((eflomal, parameters.GetEflomalIterationCount(modelType)));
             }
             else

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
@@ -96,9 +96,15 @@ namespace SIL.Machine.Translation.Thot
                     Thot.swAlignModel_setEflomalP0(eflomal, parameters.EflomalP0.Value);
                 if (parameters.EflomalJumpWindow.HasValue)
                     Thot.swAlignModel_setEflomalJumpWindow(eflomal, parameters.EflomalJumpWindow.Value);
-                // The iteration count is resolved from the model after startTraining, since the
-                // automatic schedule depends on the corpus size (see TrainAsync).
-                _models.Add((eflomal, 0));
+                // With an explicit schedule the total sweep count is known up front; with the
+                // automatic (corpus-scaled) schedule it is 0 here and resolved from the model after
+                // startTraining (see TrainAsync).
+                int eflomalIterationCount = parameters.IsEflomalScheduleSpecified
+                    ? parameters.GetEflomalIbm1IterationCount()
+                        + parameters.GetEflomalHmmIterationCount()
+                        + parameters.GetEflomalFertilityIterationCount()
+                    : 0;
+                _models.Add((eflomal, eflomalIterationCount));
             }
             else
             {
@@ -197,11 +203,13 @@ namespace SIL.Machine.Translation.Thot
         {
             // One step to load the corpus, then for each trained model one step to start training plus
             // one per training iteration. When the Eflomal model uses its automatic schedule, the
-            // iteration count is derived from the corpus during startTraining, so the total step count
-            // is not known up front; progress is reported as indeterminate until it is resolved below.
-            int? numSteps = _isEflomal
-                ? (int?)null
-                : _models.Select(m => m.IterationCount).Where(ic => ic > 0).Sum(ic => ic + 1) + 1;
+            // iteration count is derived from the corpus during startTraining (stored as 0 until then),
+            // so the total step count is not known up front; progress is reported as indeterminate until
+            // it is resolved below.
+            bool iterationCountKnown = !_isEflomal || _models[0].IterationCount > 0;
+            int? numSteps = iterationCountKnown
+                ? _models.Select(m => m.IterationCount).Where(ic => ic > 0).Sum(ic => ic + 1) + 1
+                : (int?)null;
             int curStep = 0;
 
             void Report() =>
@@ -244,10 +252,10 @@ namespace SIL.Machine.Translation.Thot
                 trainedSegmentCount = (int)Thot.swAlignModel_startTraining(handle);
 
                 int iterationCount = storedIterationCount;
-                if (_isEflomal)
+                if (_isEflomal && storedIterationCount == 0)
                 {
-                    // The (possibly automatic) schedule is resolved during startTraining; ask the model
-                    // how many sweeps to run and finalize the total step count now that it is known.
+                    // Automatic schedule: the corpus-scaled sweep count is resolved during startTraining;
+                    // ask the model how many sweeps to run and finalize the total step count now.
                     iterationCount = Thot.swAlignModel_getEflomalScheduledIterations(handle);
                     numSteps = curStep + iterationCount + 1;
                 }

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
@@ -55,6 +55,30 @@ namespace SIL.Machine.Translation.Thot
                     Thot.swAlignModel_setFastAlignP0(fastAlign, parameters.FastAlignP0.Value);
                 _models.Add((fastAlign, parameters.GetFastAlignIterationCount(modelType)));
             }
+            else if (modelType == ThotWordAlignmentModelType.Eflomal)
+            {
+                // Eflomal is a single model that runs its own Bayesian IBM1->HMM->fertility cascade.
+                IntPtr eflomal = Thot.CreateAlignmentModel(modelType);
+                if (eflomal == IntPtr.Zero)
+                {
+                    throw new NotSupportedException(
+                        "Eflomal alignment model is not supported by the installed Thot native library. "
+                            + "A Thot build that includes EflomalAlignmentModel (model type 9) is required."
+                    );
+                }
+                int numSamplers = parameters.GetEflomalNumSamplers(modelType);
+                if (numSamplers != 1)
+                {
+                    // swAlignModel_setEflomalNumSamplers requires thot with multi-sampler support.
+                    // Skip when numSamplers == 1 (the C++ default) so the call is a no-op on older builds.
+                    try
+                    {
+                        Thot.swAlignModel_setEflomalNumSamplers(eflomal, numSamplers);
+                    }
+                    catch (EntryPointNotFoundException) { }
+                }
+                _models.Add((eflomal, parameters.GetEflomalIterationCount(modelType)));
+            }
             else
             {
                 IntPtr ibm1 = Thot.CreateAlignmentModel(ThotWordAlignmentModelType.Ibm1);

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelTrainer.cs
@@ -19,6 +19,7 @@ namespace SIL.Machine.Translation.Thot
         private readonly string _targetFileName;
         private readonly int _maxSegmentLength = int.MaxValue;
         private readonly List<(IntPtr Handle, int IterationCount)> _models;
+        private readonly bool _isEflomal;
 
         public ThotWordAlignmentModelTrainer(
             ThotWordAlignmentModelType modelType,
@@ -58,6 +59,7 @@ namespace SIL.Machine.Translation.Thot
             else if (modelType == ThotWordAlignmentModelType.Eflomal)
             {
                 // Eflomal is a single model that runs its own Bayesian IBM1->HMM->fertility cascade.
+                _isEflomal = true;
                 IntPtr eflomal = Thot.CreateAlignmentModel(modelType);
                 if (eflomal == IntPtr.Zero)
                 {
@@ -66,23 +68,17 @@ namespace SIL.Machine.Translation.Thot
                             + "A Thot build that includes EflomalAlignmentModel (model type 9) is required."
                     );
                 }
-                int numSamplers = parameters.GetEflomalNumSamplers(modelType);
-                if (numSamplers != 1)
+                if (parameters.EflomalSeed.HasValue)
+                    Thot.swAlignModel_setEflomalSeed(eflomal, parameters.EflomalSeed.Value);
+                if (parameters.EflomalNumSamplers.HasValue)
+                    Thot.swAlignModel_setEflomalNumSamplers(eflomal, parameters.EflomalNumSamplers.Value);
+                if (parameters.EflomalDeterministic.HasValue)
+                    Thot.swAlignModel_setEflomalDeterministic(eflomal, parameters.EflomalDeterministic.Value);
+                if (parameters.EflomalLexNorm.HasValue)
+                    Thot.swAlignModel_setEflomalLexNorm(eflomal, parameters.EflomalLexNorm.Value);
+                if (parameters.IsEflomalScheduleSpecified)
                 {
-                    // swAlignModel_setEflomalNumSamplers requires thot with multi-sampler support.
-                    // Skip when numSamplers == 1 (the C++ default) so the call is a no-op on older builds.
-                    try
-                    {
-                        Thot.swAlignModel_setEflomalNumSamplers(eflomal, numSamplers);
-                    }
-                    catch (EntryPointNotFoundException) { }
-                }
-                if (
-                    parameters.EflomalIbm1IterationCount.HasValue
-                    || parameters.EflomalHmmIterationCount.HasValue
-                    || parameters.EflomalFertilityIterationCount.HasValue
-                )
-                {
+                    // An explicit schedule turns off the model's automatic (corpus-scaled) schedule.
                     Thot.swAlignModel_setEflomalIterations(
                         eflomal,
                         parameters.GetEflomalIbm1IterationCount(),
@@ -92,17 +88,17 @@ namespace SIL.Machine.Translation.Thot
                 }
                 if (parameters.EflomalLexAlpha.HasValue)
                     Thot.swAlignModel_setEflomalAlphaLex(eflomal, parameters.EflomalLexAlpha.Value);
-                if (parameters.EflomalNullAlpha.HasValue)
-                    Thot.swAlignModel_setEflomalAlphaNull(eflomal, parameters.EflomalNullAlpha.Value);
                 if (parameters.EflomalJumpAlpha.HasValue)
                     Thot.swAlignModel_setEflomalAlphaJump(eflomal, parameters.EflomalJumpAlpha.Value);
                 if (parameters.EflomalFertilityAlpha.HasValue)
                     Thot.swAlignModel_setEflomalAlphaFertility(eflomal, parameters.EflomalFertilityAlpha.Value);
-                if (parameters.EflomalNullProb.HasValue)
-                    Thot.swAlignModel_setEflomalNullProb(eflomal, parameters.EflomalNullProb.Value);
+                if (parameters.EflomalP0.HasValue)
+                    Thot.swAlignModel_setEflomalP0(eflomal, parameters.EflomalP0.Value);
                 if (parameters.EflomalJumpWindow.HasValue)
                     Thot.swAlignModel_setEflomalJumpWindow(eflomal, parameters.EflomalJumpWindow.Value);
-                _models.Add((eflomal, parameters.GetEflomalIterationCount(modelType)));
+                // The iteration count is resolved from the model after startTraining, since the
+                // automatic schedule depends on the corpus size (see TrainAsync).
+                _models.Add((eflomal, 0));
             }
             else
             {
@@ -199,10 +195,21 @@ namespace SIL.Machine.Translation.Thot
 
         public Task TrainAsync(IProgress<ProgressStatus> progress = null, CancellationToken cancellationToken = default)
         {
-            int numSteps = _models.Select(m => m.IterationCount).Where(ic => ic > 0).Sum(ic => ic + 1) + 1;
+            // One step to load the corpus, then for each trained model one step to start training plus
+            // one per training iteration. When the Eflomal model uses its automatic schedule, the
+            // iteration count is derived from the corpus during startTraining, so the total step count
+            // is not known up front; progress is reported as indeterminate until it is resolved below.
+            int? numSteps = _isEflomal
+                ? (int?)null
+                : _models.Select(m => m.IterationCount).Where(ic => ic > 0).Sum(ic => ic + 1) + 1;
             int curStep = 0;
 
-            progress?.Report(new ProgressStatus(curStep, numSteps));
+            void Report() =>
+                progress?.Report(
+                    numSteps.HasValue ? new ProgressStatus(curStep, numSteps.Value) : new ProgressStatus(curStep)
+                );
+
+            Report();
 
             if (!string.IsNullOrEmpty(_sourceFileName) && !string.IsNullOrEmpty(_targetFileName))
             {
@@ -225,25 +232,35 @@ namespace SIL.Machine.Translation.Thot
                 }
             }
             curStep++;
-            progress?.Report(new ProgressStatus(curStep, numSteps));
+            Report();
             cancellationToken.ThrowIfCancellationRequested();
 
             int trainedSegmentCount = 0;
-            foreach ((IntPtr handle, int iterationCount) in _models)
+            foreach ((IntPtr handle, int storedIterationCount) in _models)
             {
-                if (iterationCount == 0)
+                if (storedIterationCount == 0 && !_isEflomal)
                     continue;
 
                 trainedSegmentCount = (int)Thot.swAlignModel_startTraining(handle);
+
+                int iterationCount = storedIterationCount;
+                if (_isEflomal)
+                {
+                    // The (possibly automatic) schedule is resolved during startTraining; ask the model
+                    // how many sweeps to run and finalize the total step count now that it is known.
+                    iterationCount = Thot.swAlignModel_getEflomalScheduledIterations(handle);
+                    numSteps = curStep + iterationCount + 1;
+                }
+
                 curStep++;
-                progress?.Report(new ProgressStatus(curStep, numSteps));
+                Report();
                 cancellationToken.ThrowIfCancellationRequested();
 
                 for (int i = 0; i < iterationCount; i++)
                 {
                     Thot.swAlignModel_train(handle, 1);
                     curStep++;
-                    progress?.Report(new ProgressStatus(curStep, numSteps));
+                    Report();
                     cancellationToken.ThrowIfCancellationRequested();
                 }
                 Thot.swAlignModel_endTraining(handle);

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelType.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentModelType.cs
@@ -8,6 +8,7 @@
         Hmm,
         Ibm3,
         Ibm4,
+        Eflomal,
     }
 
     public class ThotWordAlignmentModelTypeHelpers
@@ -30,6 +31,8 @@
                     return ThotWordAlignmentModelType.Ibm3;
                 case "ibm4":
                     return ThotWordAlignmentModelType.Ibm4;
+                case "eflomal":
+                    return ThotWordAlignmentModelType.Eflomal;
             }
         }
     }

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
@@ -11,7 +11,38 @@ namespace SIL.Machine.Translation.Thot
         public int? Ibm4IterationCount { get; set; }
         public int? FastAlignIterationCount { get; set; }
         public int? EflomalIterationCount { get; set; }
+        public int? EflomalIbm1IterationCount { get; set; }
+        public int? EflomalHmmIterationCount { get; set; }
+        public int? EflomalFertilityIterationCount { get; set; }
         public int? EflomalNumSamplers { get; set; }
+
+        /// <summary>Lexical Dirichlet prior for non-NULL source words. Matches eflomal LEX_ALPHA. Default 0.001.</summary>
+        public double? EflomalLexAlpha { get; set; }
+
+        /// <summary>
+        /// Lexical Dirichlet prior for the NULL source word. Matches eflomal NULL_ALPHA. Default 0.001.
+        /// Separate from <see cref="EflomalLexAlpha"/> so the null word's smoothing can be tuned
+        /// independently from the regular source vocabulary.
+        /// </summary>
+        public double? EflomalNullAlpha { get; set; }
+
+        /// <summary>Jump distribution Dirichlet prior. Matches eflomal JUMP_ALPHA. Default 0.5.</summary>
+        public double? EflomalJumpAlpha { get; set; }
+
+        /// <summary>Fertility distribution Dirichlet prior. Matches eflomal FERT_ALPHA. Default 0.5.</summary>
+        public double? EflomalFertilityAlpha { get; set; }
+
+        /// <summary>
+        /// Fixed probability of aligning a target token to the NULL source word (IBM1 mixing weight).
+        /// Not a Dirichlet prior; controls the null/non-null split before lexical sampling. Default 0.2.
+        /// </summary>
+        public double? EflomalNullProb { get; set; }
+
+        /// <summary>
+        /// Half-width of the jump distribution window. Offsets beyond ±JumpWindow are clamped.
+        /// Roughly corresponds to eflomal JUMP_MAX_EST. Default 100.
+        /// </summary>
+        public int? EflomalJumpWindow { get; set; }
         public bool? VariationalBayes { get; set; }
         public double? FastAlignP0 { get; set; }
         public double? HmmP0 { get; set; }
@@ -64,14 +95,23 @@ namespace SIL.Machine.Translation.Thot
         }
 
         // Eflomal runs its IBM1->HMM->fertility cascade internally, so the trainer drives a single
-        // model for the total number of sweeps. The default of 12 matches the native model's
-        // default 4/4/4 stage schedule.
+        // model for the total number of sweeps.
+        // When per-stage counts are set, the total is their sum; otherwise EflomalIterationCount
+        // is used (default 12, matching the C++ model's default 4/4/4 schedule).
         public int GetEflomalIterationCount(ThotWordAlignmentModelType modelType)
         {
-            if (modelType == ThotWordAlignmentModelType.Eflomal)
-                return EflomalIterationCount ?? 12;
-            return 0;
+            if (modelType != ThotWordAlignmentModelType.Eflomal)
+                return 0;
+            if (EflomalIbm1IterationCount.HasValue || EflomalHmmIterationCount.HasValue || EflomalFertilityIterationCount.HasValue)
+                return GetEflomalIbm1IterationCount() + GetEflomalHmmIterationCount() + GetEflomalFertilityIterationCount();
+            return EflomalIterationCount ?? 12;
         }
+
+        public int GetEflomalIbm1IterationCount() => EflomalIbm1IterationCount ?? 4;
+
+        public int GetEflomalHmmIterationCount() => EflomalHmmIterationCount ?? 4;
+
+        public int GetEflomalFertilityIterationCount() => EflomalFertilityIterationCount ?? 4;
 
         /// <summary>
         /// Number of independent Gibbs chains trained in parallel. Marginals are summed across

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
@@ -10,6 +10,8 @@ namespace SIL.Machine.Translation.Thot
         public int? Ibm3IterationCount { get; set; }
         public int? Ibm4IterationCount { get; set; }
         public int? FastAlignIterationCount { get; set; }
+        public int? EflomalIterationCount { get; set; }
+        public int? EflomalNumSamplers { get; set; }
         public bool? VariationalBayes { get; set; }
         public double? FastAlignP0 { get; set; }
         public double? HmmP0 { get; set; }
@@ -59,6 +61,27 @@ namespace SIL.Machine.Translation.Thot
             if (modelType == ThotWordAlignmentModelType.FastAlign)
                 return FastAlignIterationCount ?? 4;
             return 0;
+        }
+
+        // Eflomal runs its IBM1->HMM->fertility cascade internally, so the trainer drives a single
+        // model for the total number of sweeps. The default of 12 matches the native model's
+        // default 4/4/4 stage schedule.
+        public int GetEflomalIterationCount(ThotWordAlignmentModelType modelType)
+        {
+            if (modelType == ThotWordAlignmentModelType.Eflomal)
+                return EflomalIterationCount ?? 12;
+            return 0;
+        }
+
+        /// <summary>
+        /// Number of independent Gibbs chains trained in parallel. Marginals are summed across
+        /// chains at decode time (eflomal's n_samplers scheme). Default 1.
+        /// </summary>
+        public int GetEflomalNumSamplers(ThotWordAlignmentModelType modelType)
+        {
+            if (modelType == ThotWordAlignmentModelType.Eflomal)
+                return EflomalNumSamplers ?? 1;
+            return 1;
         }
 
         public bool GetVariationalBayes(ThotWordAlignmentModelType modelType)

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
@@ -10,21 +10,33 @@ namespace SIL.Machine.Translation.Thot
         public int? Ibm3IterationCount { get; set; }
         public int? Ibm4IterationCount { get; set; }
         public int? FastAlignIterationCount { get; set; }
-        public int? EflomalIterationCount { get; set; }
-        public int? EflomalIbm1IterationCount { get; set; }
-        public int? EflomalHmmIterationCount { get; set; }
-        public int? EflomalFertilityIterationCount { get; set; }
-        public int? EflomalNumSamplers { get; set; }
-
-        /// <summary>Lexical Dirichlet prior for non-NULL source words. Matches eflomal LEX_ALPHA. Default 0.001.</summary>
-        public double? EflomalLexAlpha { get; set; }
 
         /// <summary>
-        /// Lexical Dirichlet prior for the NULL source word. Matches eflomal NULL_ALPHA. Default 0.001.
-        /// Separate from <see cref="EflomalLexAlpha"/> so the null word's smoothing can be tuned
-        /// independently from the regular source vocabulary.
+        /// Number of independent Gibbs chains trained in parallel. Marginals are summed across
+        /// chains at decode time (eflomal's n_samplers scheme). Default 3.
         /// </summary>
-        public double? EflomalNullAlpha { get; set; }
+        public int? EflomalNumSamplers { get; set; }
+
+        /// <summary>
+        /// Trains the Gibbs sampler chains serially rather than across threads, so a fixed seed
+        /// produces a reproducible model at the cost of parallelism. Default false.
+        /// </summary>
+        public bool? EflomalDeterministic { get; set; }
+
+        /// <summary>
+        /// Random seed for the Gibbs samplers. Chain <c>s</c> is seeded with <c>seed + s * 2654435761</c>.
+        /// Combine with <see cref="EflomalDeterministic"/> for fully reproducible training. Default 1351155463.
+        /// </summary>
+        public uint? EflomalSeed { get; set; }
+
+        /// <summary>
+        /// When true, the lexical model uses the plain denominator <c>1/N(e)</c> instead of the
+        /// Dirichlet-smoothed <c>1/(N(e) + alphaLex * |V|)</c>. Default true.
+        /// </summary>
+        public bool? EflomalLexNorm { get; set; }
+
+        /// <summary>Lexical Dirichlet prior for source words. Matches eflomal LEX_ALPHA. Default 0.001.</summary>
+        public double? EflomalLexAlpha { get; set; }
 
         /// <summary>Jump distribution Dirichlet prior. Matches eflomal JUMP_ALPHA. Default 0.5.</summary>
         public double? EflomalJumpAlpha { get; set; }
@@ -36,7 +48,7 @@ namespace SIL.Machine.Translation.Thot
         /// Fixed probability of aligning a target token to the NULL source word (IBM1 mixing weight).
         /// Not a Dirichlet prior; controls the null/non-null split before lexical sampling. Default 0.2.
         /// </summary>
-        public double? EflomalNullProb { get; set; }
+        public double? EflomalP0 { get; set; }
 
         /// <summary>
         /// Half-width of the jump distribution window. Offsets beyond ±JumpWindow are clamped.
@@ -94,43 +106,24 @@ namespace SIL.Machine.Translation.Thot
             return 0;
         }
 
-        // Eflomal runs its IBM1->HMM->fertility cascade internally, so the trainer drives a single
-        // model for the total number of sweeps.
-        // When per-stage counts are set, the total is their sum; otherwise EflomalIterationCount
-        // is used (default 12, matching the C++ model's default 4/4/4 schedule).
-        public int GetEflomalIterationCount(ThotWordAlignmentModelType modelType)
-        {
-            if (modelType != ThotWordAlignmentModelType.Eflomal)
-                return 0;
-            if (
-                EflomalIbm1IterationCount.HasValue
-                || EflomalHmmIterationCount.HasValue
-                || EflomalFertilityIterationCount.HasValue
-            )
-            {
-                return GetEflomalIbm1IterationCount()
-                    + GetEflomalHmmIterationCount()
-                    + GetEflomalFertilityIterationCount();
-            }
-            return EflomalIterationCount ?? 12;
-        }
+        // Eflomal runs its IBM1->HMM->fertility cascade internally as a single model, reusing the
+        // IBM1/HMM/IBM3 iteration counts for its three stages (IBM3 drives the fertility stage).
+        // When none of them are specified, the model derives the schedule automatically from the
+        // corpus size, so no explicit schedule should be set. When only some are specified, the
+        // rest fall back to the Thot model's per-stage defaults (DefaultIbm1Iters/DefaultHmmIters/
+        // DefaultFertilityIters).
+        private const int DefaultEflomalIbm1IterationCount = 8;
+        private const int DefaultEflomalHmmIterationCount = 8;
+        private const int DefaultEflomalFertilityIterationCount = 32;
 
-        public int GetEflomalIbm1IterationCount() => EflomalIbm1IterationCount ?? 4;
+        public bool IsEflomalScheduleSpecified =>
+            Ibm1IterationCount.HasValue || HmmIterationCount.HasValue || Ibm3IterationCount.HasValue;
 
-        public int GetEflomalHmmIterationCount() => EflomalHmmIterationCount ?? 4;
+        public int GetEflomalIbm1IterationCount() => Ibm1IterationCount ?? DefaultEflomalIbm1IterationCount;
 
-        public int GetEflomalFertilityIterationCount() => EflomalFertilityIterationCount ?? 4;
+        public int GetEflomalHmmIterationCount() => HmmIterationCount ?? DefaultEflomalHmmIterationCount;
 
-        /// <summary>
-        /// Number of independent Gibbs chains trained in parallel. Marginals are summed across
-        /// chains at decode time (eflomal's n_samplers scheme). Default 1.
-        /// </summary>
-        public int GetEflomalNumSamplers(ThotWordAlignmentModelType modelType)
-        {
-            if (modelType == ThotWordAlignmentModelType.Eflomal)
-                return EflomalNumSamplers ?? 1;
-            return 1;
-        }
+        public int GetEflomalFertilityIterationCount() => Ibm3IterationCount ?? DefaultEflomalFertilityIterationCount;
 
         public bool GetVariationalBayes(ThotWordAlignmentModelType modelType)
         {

--- a/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
+++ b/src/SIL.Machine.Translation.Thot/ThotWordAlignmentParameters.cs
@@ -102,8 +102,16 @@ namespace SIL.Machine.Translation.Thot
         {
             if (modelType != ThotWordAlignmentModelType.Eflomal)
                 return 0;
-            if (EflomalIbm1IterationCount.HasValue || EflomalHmmIterationCount.HasValue || EflomalFertilityIterationCount.HasValue)
-                return GetEflomalIbm1IterationCount() + GetEflomalHmmIterationCount() + GetEflomalFertilityIterationCount();
+            if (
+                EflomalIbm1IterationCount.HasValue
+                || EflomalHmmIterationCount.HasValue
+                || EflomalFertilityIterationCount.HasValue
+            )
+            {
+                return GetEflomalIbm1IterationCount()
+                    + GetEflomalHmmIterationCount()
+                    + GetEflomalFertilityIterationCount();
+            }
             return EflomalIterationCount ?? 12;
         }
 

--- a/tests/SIL.Machine.Translation.Thot.Tests/ThotEflomalWordAlignmentModelTests.cs
+++ b/tests/SIL.Machine.Translation.Thot.Tests/ThotEflomalWordAlignmentModelTests.cs
@@ -1,0 +1,134 @@
+using NUnit.Framework;
+using SIL.Machine.Corpora;
+using SIL.Machine.Utils;
+
+namespace SIL.Machine.Translation.Thot;
+
+[TestFixture]
+public class ThotEflomalWordAlignmentModelTests
+{
+    [OneTimeSetUp]
+    public void RequireEflomalSupport()
+    {
+        bool supported;
+        try
+        {
+            var probe = new ThotWordAlignmentModelTrainer(
+                ThotWordAlignmentModelType.Eflomal,
+                TestHelpers.CreateTestParallelCorpus(),
+                "probe"
+            );
+            probe.Dispose();
+            supported = true;
+        }
+        catch (NotSupportedException)
+        {
+            supported = false;
+        }
+        Assume.That(supported, Is.True, "Eflomal requires a Thot build that includes EflomalAlignmentModel");
+    }
+
+    private static ThotEflomalWordAlignmentModel TrainModel(string? prefFileName = null)
+    {
+        var model = new ThotEflomalWordAlignmentModel
+        {
+            Parameters = new ThotWordAlignmentParameters { EflomalIterationCount = 12 },
+        };
+        if (prefFileName != null)
+            model.CreateNew(prefFileName);
+        ITrainer trainer = model.CreateTrainer(TestHelpers.CreateTestParallelCorpus());
+        trainer.TrainAsync().GetAwaiter().GetResult();
+        trainer.SaveAsync().GetAwaiter().GetResult();
+        return model;
+    }
+
+    [Test]
+    public void CreateTrainerAndAlign()
+    {
+        using ThotEflomalWordAlignmentModel model = TrainModel();
+
+        WordAlignmentMatrix matrix = model.Align("isthay isyay ayay esttay-N .".Split(), "this is a test N .".Split());
+        // The Bayesian sampler is deterministic for a fixed seed, but we assert structural
+        // plausibility rather than an exact matrix so the test is robust to schedule tuning.
+        Assert.That(matrix.RowCount, Is.EqualTo(5));
+        Assert.That(matrix.ColumnCount, Is.EqualTo(6));
+        Assert.That(matrix.ToString(), Does.Contain("0-0")); // "this" aligns to "isthay"
+        Assert.That(matrix.ToString().Trim(), Is.Not.Empty);
+    }
+
+    [Test]
+    public void AlignBatch()
+    {
+        using ThotEflomalWordAlignmentModel model = TrainModel();
+
+        (string, string)[] batch =
+        {
+            ("isthay isyay ayay esttay-N .", "this is a test N ."),
+            ("ouyay ouldshay esttay-V oftenyay .", "you should test V often ."),
+            ("isyay isthay orkingway ?", "is this working ?"),
+        };
+        IReadOnlyList<WordAlignmentMatrix> alignments = model.AlignBatch(
+            batch
+                .Select(p => ((IReadOnlyList<string>)p.Item1.Split(), (IReadOnlyList<string>)p.Item2.Split()))
+                .ToArray()
+        );
+        Assert.That(alignments.Count, Is.EqualTo(3));
+        Assert.That(alignments.All(m => !string.IsNullOrWhiteSpace(m.ToString())), Is.True);
+    }
+
+    [Test]
+    public void GetTranslationProbability()
+    {
+        using ThotEflomalWordAlignmentModel model = TrainModel();
+
+        // After training the model should strongly associate the obvious translation.
+        Assert.That(model.GetTranslationProbability("isthay", "this"), Is.GreaterThan(0.1));
+    }
+
+    [Test]
+    public void SourceAndTargetWords()
+    {
+        using ThotEflomalWordAlignmentModel model = TrainModel();
+
+        Assert.That(model.SourceWords.Count, Is.GreaterThan(0));
+        Assert.That(model.TargetWords.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void SaveAndLoadRoundTrip()
+    {
+        using var tempDir = new TempDirectory("ThotEflomalWordAlignmentModelTests");
+        string prefix = Path.Combine(tempDir.Path, "src_trg_invswm");
+
+        WordAlignmentMatrix trained;
+        using (ThotEflomalWordAlignmentModel model = TrainModel(prefix))
+        {
+            trained = model.Align("isthay isyay ayay esttay-N .".Split(), "this is a test N .".Split());
+        }
+
+        using var loaded = new ThotEflomalWordAlignmentModel(prefix);
+        WordAlignmentMatrix reloaded = loaded.Align(
+            "isthay isyay ayay esttay-N .".Split(),
+            "this is a test N .".Split()
+        );
+        Assert.That(reloaded.ValueEquals(trained), Is.True);
+    }
+
+    [Test]
+    public void SymmetrizedAlignment()
+    {
+        using var tempDir = new TempDirectory("ThotEflomalWordAlignmentModelTests");
+        using var direct = TrainModel(Path.Combine(tempDir.Path, "src_trg_invswm"));
+        using var inverse = new ThotEflomalWordAlignmentModel();
+        ITrainer invTrainer = inverse.CreateTrainer(TestHelpers.CreateTestParallelCorpus().Invert());
+        invTrainer.TrainAsync().GetAwaiter().GetResult();
+        invTrainer.SaveAsync().GetAwaiter().GetResult();
+
+        using var symmetrized = new SymmetrizedWordAlignmentModel(direct, inverse);
+        WordAlignmentMatrix matrix = symmetrized.Align(
+            "isthay isyay ayay esttay-N .".Split(),
+            "this is a test N .".Split()
+        );
+        Assert.That(matrix.ToString().Trim(), Is.Not.Empty);
+    }
+}

--- a/tests/SIL.Machine.Translation.Thot.Tests/ThotEflomalWordAlignmentModelTests.cs
+++ b/tests/SIL.Machine.Translation.Thot.Tests/ThotEflomalWordAlignmentModelTests.cs
@@ -30,10 +30,9 @@ public class ThotEflomalWordAlignmentModelTests
 
     private static ThotEflomalWordAlignmentModel TrainModel(string? prefFileName = null)
     {
-        var model = new ThotEflomalWordAlignmentModel
-        {
-            Parameters = new ThotWordAlignmentParameters { EflomalIterationCount = 12 },
-        };
+        // No iteration counts are specified, so Eflomal derives its schedule automatically from
+        // the corpus size (the recommended default).
+        var model = new ThotEflomalWordAlignmentModel();
         if (prefFileName != null)
             model.CreateNew(prefFileName);
         ITrainer trainer = model.CreateTrainer(TestHelpers.CreateTestParallelCorpus());
@@ -83,6 +82,81 @@ public class ThotEflomalWordAlignmentModelTests
 
         // After training the model should strongly associate the obvious translation.
         Assert.That(model.GetTranslationProbability("isthay", "this"), Is.GreaterThan(0.1));
+    }
+
+    [Test]
+    public void DeterministicTrainingIsReproducible()
+    {
+        static WordAlignmentMatrix TrainDeterministic()
+        {
+            using var model = new ThotEflomalWordAlignmentModel
+            {
+                Parameters = new ThotWordAlignmentParameters { EflomalDeterministic = true },
+            };
+            ITrainer trainer = model.CreateTrainer(TestHelpers.CreateTestParallelCorpus());
+            trainer.TrainAsync().GetAwaiter().GetResult();
+            return model.Align("isthay isyay ayay esttay-N .".Split(), "this is a test N .".Split());
+        }
+
+        // With deterministic training the chains run serially from a fixed seed, so two separate
+        // training runs produce an identical model.
+        WordAlignmentMatrix first = TrainDeterministic();
+        WordAlignmentMatrix second = TrainDeterministic();
+        Assert.That(second.ValueEquals(first), Is.True);
+    }
+
+    [Test]
+    public void SeedAndLexNormAreApplied()
+    {
+        static WordAlignmentMatrix Train(uint seed, bool lexNorm)
+        {
+            using var model = new ThotEflomalWordAlignmentModel
+            {
+                Parameters = new ThotWordAlignmentParameters
+                {
+                    EflomalSeed = seed,
+                    EflomalDeterministic = true,
+                    EflomalLexNorm = lexNorm,
+                },
+            };
+            ITrainer trainer = model.CreateTrainer(TestHelpers.CreateTestParallelCorpus());
+            trainer.TrainAsync().GetAwaiter().GetResult();
+            return model.Align("isthay isyay ayay esttay-N .".Split(), "this is a test N .".Split());
+        }
+
+        // A fixed seed with deterministic training is reproducible across separate runs.
+        Assert.That(Train(12345, lexNorm: true).ValueEquals(Train(12345, lexNorm: true)), Is.True);
+        // Both lexical-normalization modes train and produce a valid alignment.
+        Assert.That(Train(12345, lexNorm: false).ToString().Trim(), Is.Not.Empty);
+    }
+
+    [Test]
+    public void CreateTrainerWithExplicitSchedule()
+    {
+        // Specifying the IBM1/HMM/IBM3 iteration counts overrides the automatic schedule with an
+        // explicit IBM1 -> HMM -> fertility (IBM3) schedule.
+        var model = new ThotEflomalWordAlignmentModel
+        {
+            Parameters = new ThotWordAlignmentParameters
+            {
+                Ibm1IterationCount = 50,
+                HmmIterationCount = 50,
+                Ibm3IterationCount = 200,
+            },
+        };
+        ITrainer trainer = model.CreateTrainer(TestHelpers.CreateTestParallelCorpus());
+        trainer.TrainAsync().GetAwaiter().GetResult();
+        trainer.SaveAsync().GetAwaiter().GetResult();
+
+        using (model)
+        {
+            WordAlignmentMatrix matrix = model.Align(
+                "isthay isyay ayay esttay-N .".Split(),
+                "this is a test N .".Split()
+            );
+            Assert.That(matrix.ToString(), Does.Contain("0-0")); // "this" aligns to "isthay"
+            Assert.That(model.GetTranslationProbability("isthay", "this"), Is.GreaterThan(0.1));
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Wires `EflomalAlignmentModel` from thot into machine's alignment pipeline. eflomal is a Bayesian IBM1→HMM→fertility cascade trained by collapsed Gibbs sampling. Depends on **Thot 3.5.0** (released to NuGet; implementation in **sillsdev/thot#11**).

### Changes

**`ThotWordAlignmentModelType` / `ToolHelpers`** — `Eflomal` enum value + `"eflomal"` string alias.

**`ThotEflomalWordAlignmentModel`** — new class. Because eflomal is an HMM-based aligner, it implements `IHmmWordAlignmentModel` and shares the alignment-scoring logic with `ThotHmmWordAlignmentModel` via a new abstract base, `ThotHmmWordAlignmentModelBase` (extracted from the HMM model so the two are siblings rather than one subclassing the other). Its alignment scores come from `swAlignModel_getEflomalAlignmentProbability`. Added to the `ThotWordAlignmentModel.Create` factory.

**`ThotHmmWordAlignmentModelBase`** — new abstract base holding the shared `ComputeAlignedWordPairScores`; concrete `ThotHmmWordAlignmentModel` and `ThotEflomalWordAlignmentModel` supply only their model type and the underlying C API call.

**`ThotFastAlignWordAlignmentModel`** — now uses the FastAlign-specific `swAlignModel_getFastAlignAlignmentProbability` instead of borrowing the IBM2 entry point (the new thot binary dispatches by model type, so the IBM2 path would return 0 for a FastAlign model).

**`ThotWordAlignmentModelTrainer`** — Eflomal branch creates a single model that runs the full IBM1→HMM→fertility cascade internally. Key behavior:

- **Iterations reuse the standard counts.** `Ibm1IterationCount` → IBM1 stage, `HmmIterationCount` → HMM stage, `Ibm3IterationCount` → fertility stage. The separate `Eflomal*IterationCount` properties are gone.
- **Auto schedule by default.** If none of those counts are set, the model derives its corpus-scaled schedule automatically (thot default). The trainer then reads the resolved count via `swAlignModel_getEflomalScheduledIterations` *after* `startTraining` and drives exactly that many sweeps — required because the schedule (and the staged cascade) isn't known up front. Progress is reported as indeterminate until it resolves.
- Applies the eflomal hyperparameters (below) when set.

**`ThotWordAlignmentParameters`** — reworked eflomal hyperparameters to match the thot 3.5.0 C API:

- `EflomalNumSamplers` — parallel Gibbs chains; marginals summed across chains before argmax (eflomal's `n_samplers`). Thot default 3 (left untouched unless set).
- `EflomalSeed` — RNG seed for the samplers.
- `EflomalDeterministic` — trains chains serially so a fixed seed is reproducible.
- `EflomalLexNorm` — plain `1/N(e)` vs Dirichlet-smoothed lexical denominator.
- `EflomalLexAlpha` / `EflomalJumpAlpha` / `EflomalFertilityAlpha` — Dirichlet priors.
- `EflomalP0` — NULL-alignment mixing weight (renamed from the removed `EflomalNullProb`).
- `EflomalJumpWindow` — jump-distribution half-window.
- Removed `EflomalNullAlpha` (no longer in the API). Partial schedules fall back to thot's per-stage defaults (8 / 8 / 32).

**`Thot.cs`** — P/Invoke declarations for the eflomal API (`setEflomalSeed`/`NumSamplers`/`Deterministic`/`Iterations`/`AutoIterations`/`LexNorm`/`P0`/`AlphaLex`/`AlphaJump`/`AlphaFertility`/`JumpWindow`, `getEflomalScheduledIterations`, `getEflomalAlignmentProbability`) and `swAlignModel_getFastAlignAlignmentProbability`.

**`AlignmentModelCommandSpec`** — eflomal reuses the `--ibm1-iters` / `--hmm-iters` / `--ibm3-iters` flags for its schedule; new `--eflomal-samplers`, `--eflomal-deterministic`, `--eflomal-seed`, `--eflomal-lex-norm`, `--eflomal-lex-alpha`, `--eflomal-jump-alpha`, `--eflomal-fert-alpha`, `--eflomal-p0`, `--eflomal-jump-window` flags.

### Test plan

- [x] `ThotEflomalWordAlignmentModelTests`: CreateTrainer+Align, AlignBatch, translation probability, vocab counts, save/load round-trip, symmetrized model, explicit-schedule training, deterministic reproducibility, seed + lex-norm
- [x] Full machine Thot test suite passes (83/83) against released **Thot 3.5.0** from NuGet
- [x] Solution builds warning-clean in Release (`TreatWarningsAsErrors=true`)
- [x] `dotnet csharpier check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/433)
<!-- Reviewable:end -->
