### PR TITLE
Fix LT-22600: Show Hermit Crab rule statistics

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisAffixTemplateRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisAffixTemplateRule.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace SIL.Machine.Morphology.HermitCrab
 {
-    internal class AnalysisAffixTemplateRule : IRule<Word, ShapeNode>
+    internal class AnalysisAffixTemplateRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly AffixTemplate _template;
@@ -20,6 +20,7 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public AnalysisAffixTemplateRule(Morpher morpher, AffixTemplate template)
         {
+            Name = template.Name;
             _morpher = morpher;
             _template = template;
             _rules = new List<IRule<Word, ShapeNode>>(
@@ -29,9 +30,10 @@ namespace SIL.Machine.Morphology.HermitCrab
                     FreezableEqualityComparer<Word>.Default
                 ))
             );
+            AddSubRules(_rules);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_template))
                 return Enumerable.Empty<Word>();
@@ -55,6 +57,8 @@ namespace SIL.Machine.Morphology.HermitCrab
 
             foreach (Word outWord in output)
                 outWord.SyntacticFeatureStruct.Add(fs);
+
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisLanguageRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisLanguageRule.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using SIL.Machine.Annotations;
 using SIL.Machine.Rules;
@@ -23,6 +24,7 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public override IEnumerable<Word> Apply(Word input)
         {
+            long startTime = Stopwatch.GetTimestamp();
             var inputSet = new HashSet<Word>(FreezableEqualityComparer<Word>.Default) { input };
             var tempSet = new HashSet<Word>(FreezableEqualityComparer<Word>.Default);
             var results = new HashSet<Word>(FreezableEqualityComparer<Word>.Default);
@@ -47,6 +49,7 @@ namespace SIL.Machine.Morphology.HermitCrab
                 inputSet = outputSet;
             }
 
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(results.Count());
             return results;
         }

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisLanguageRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisLanguageRule.cs
@@ -6,7 +6,7 @@ using SIL.ObjectModel;
 
 namespace SIL.Machine.Morphology.HermitCrab
 {
-    internal class AnalysisLanguageRule : IRule<Word, ShapeNode>
+    internal class AnalysisLanguageRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly List<Stratum> _strata;
@@ -14,12 +14,14 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public AnalysisLanguageRule(Morpher morpher, Language language)
         {
+            Name = "Analysis";
             _morpher = morpher;
             _strata = language.Strata.Reverse().ToList();
             _rules = _strata.Select(stratum => stratum.CompileAnalysisRule(morpher)).ToList();
+            AddSubRules(_rules);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             var inputSet = new HashSet<Word>(FreezableEqualityComparer<Word>.Default) { input };
             var tempSet = new HashSet<Word>(FreezableEqualityComparer<Word>.Default);
@@ -45,6 +47,7 @@ namespace SIL.Machine.Morphology.HermitCrab
                 inputSet = outputSet;
             }
 
+            AddRuleStats(results.Count());
             return results;
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -8,7 +8,7 @@ using SIL.ObjectModel;
 
 namespace SIL.Machine.Morphology.HermitCrab
 {
-    internal class AnalysisStratumRule : IRule<Word, ShapeNode>
+    internal class AnalysisStratumRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly IRule<Word, ShapeNode> _mrulesRule;
         private readonly IRule<Word, ShapeNode> _prulesRule;
@@ -18,6 +18,7 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public AnalysisStratumRule(Morpher morpher, Stratum stratum)
         {
+            Name = stratum.Name;
             _stratum = stratum;
             _morpher = morpher;
             _prulesRule = new LinearRuleCascade<Word, ShapeNode>(
@@ -61,6 +62,9 @@ namespace SIL.Machine.Morphology.HermitCrab
 #endif
                     break;
             }
+            AddSubRule(_prulesRule);
+            AddSubRule(_templatesRule);
+            AddSubRule( _mrulesRule);
         }
 
         private IRule<Word, ShapeNode> CompileAffixTemplate(AffixTemplate template, Morpher morpher)
@@ -99,8 +103,9 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
+            long startTime = Stopwatch.GetTimestamp();
             if (_morpher.TraceManager.IsTracing)
                 _morpher.TraceManager.BeginUnapplyStratum(_stratum, input);
 
@@ -144,6 +149,9 @@ namespace SIL.Machine.Morphology.HermitCrab
                 if (_morpher.MaxUnapplications > 0 && output.Count >= _morpher.MaxUnapplications)
                     break;
             }
+
+            ElapsedTime += Stopwatch.GetTimestamp() - startTime;
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStratumRule.cs
@@ -64,7 +64,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
             AddSubRule(_prulesRule);
             AddSubRule(_templatesRule);
-            AddSubRule( _mrulesRule);
+            AddSubRule(_mrulesRule);
         }
 
         private IRule<Word, ShapeNode> CompileAffixTemplate(AffixTemplate template, Morpher morpher)
@@ -150,7 +150,7 @@ namespace SIL.Machine.Morphology.HermitCrab
                     break;
             }
 
-            ElapsedTime += Stopwatch.GetTimestamp() - startTime;
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(output.Count);
             return output;
         }

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -27,7 +27,7 @@ namespace SIL.Machine.Morphology.HermitCrab
         private readonly ITraceManager _traceManager;
         private readonly ReadOnlyObservableCollection<Morpheme> _morphemes;
         private readonly IList<RootAllomorph> _lexicalPatterns = new List<RootAllomorph>();
-        private bool _gatherCorpusStatistics = false;
+        private bool _enableCorpusStatistics = false;
 
         public Morpher(ITraceManager traceManager, Language lang)
         {
@@ -86,12 +86,12 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// </summary>
         public bool MergeEquivalentAnalyses { get; set; }
 
-        public bool GatherCorpusStatistics
+        public bool EnableCorpusStatistics
         {
-            get { return _gatherCorpusStatistics; }
+            get { return _enableCorpusStatistics; }
             set
             {
-                _gatherCorpusStatistics = value;
+                _enableCorpusStatistics = value;
                 ClearRuleStats();
             }
         }
@@ -131,7 +131,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_traceManager.IsTracing)
                 _traceManager.AnalyzeWord(_lang, input);
             trace = input.CurrentTrace;
-            if (!GatherCorpusStatistics)
+            if (!EnableCorpusStatistics)
             {
                 ClearRuleStats();
             }

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -27,6 +27,7 @@ namespace SIL.Machine.Morphology.HermitCrab
         private readonly ITraceManager _traceManager;
         private readonly ReadOnlyObservableCollection<Morpheme> _morphemes;
         private readonly IList<RootAllomorph> _lexicalPatterns = new List<RootAllomorph>();
+        private bool _gatherCorpusStatistics = false;
 
         public Morpher(ITraceManager traceManager, Language lang)
         {
@@ -85,6 +86,16 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// </summary>
         public bool MergeEquivalentAnalyses { get; set; }
 
+        public bool GatherCorpusStatistics
+        {
+            get { return _gatherCorpusStatistics; }
+            set
+            {
+                _gatherCorpusStatistics = value;
+                ClearRuleStats();
+            }
+        }
+
         public Func<LexEntry, bool> LexEntrySelector { get; set; }
         public Func<IHCRule, bool> RuleSelector { get; set; }
 
@@ -120,8 +131,10 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_traceManager.IsTracing)
                 _traceManager.AnalyzeWord(_lang, input);
             trace = input.CurrentTrace;
-            ((InstrumentedRule<Word, ShapeNode>)_analysisRule).ClearStats();
-            ((InstrumentedRule<Word, ShapeNode>)_synthesisRule).ClearStats();
+            if (!GatherCorpusStatistics)
+            {
+                ClearRuleStats();
+            }
 
             // Unapply rules
             var analyses = new ConcurrentQueue<Word>(_analysisRule.Apply(input));

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -27,7 +27,6 @@ namespace SIL.Machine.Morphology.HermitCrab
         private readonly ITraceManager _traceManager;
         private readonly ReadOnlyObservableCollection<Morpheme> _morphemes;
         private readonly IList<RootAllomorph> _lexicalPatterns = new List<RootAllomorph>();
-        private bool _enableCorpusStatistics = false;
 
         public Morpher(ITraceManager traceManager, Language lang)
         {
@@ -86,16 +85,6 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// </summary>
         public bool MergeEquivalentAnalyses { get; set; }
 
-        public bool EnableCorpusStatistics
-        {
-            get { return _enableCorpusStatistics; }
-            set
-            {
-                _enableCorpusStatistics = value;
-                ClearRuleStats();
-            }
-        }
-
         public Func<LexEntry, bool> LexEntrySelector { get; set; }
         public Func<IHCRule, bool> RuleSelector { get; set; }
 
@@ -131,10 +120,6 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_traceManager.IsTracing)
                 _traceManager.AnalyzeWord(_lang, input);
             trace = input.CurrentTrace;
-            if (!EnableCorpusStatistics)
-            {
-                ClearRuleStats();
-            }
 
             // Unapply rules
             var analyses = new ConcurrentQueue<Word>(_analysisRule.Apply(input));

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -55,7 +55,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             _synthesisRule = lang.CompileSynthesisRule(this);
             ((InstrumentedRule<Word, ShapeNode>)_synthesisRule).Name = "Synthesis";
             MaxStemCount = 2;
-            MaxUnapplications = 0;
+            MaxUnapplications = 1000;
             MergeEquivalentAnalyses = true;
             LexEntrySelector = entry => true;
             RuleSelector = rule => true;
@@ -164,6 +164,29 @@ namespace SIL.Machine.Morphology.HermitCrab
                 return matches;
             }
             return syntheses;
+        }
+
+        /// <summary>
+        /// Get the top-level rule statistics.
+        /// </summary>
+        public IEnumerable<InstrumentedRule<Word, ShapeNode>> GetRuleStats()
+        {
+            return new List<InstrumentedRule<Word, ShapeNode>>
+            {
+                _analysisRule as InstrumentedRule<Word, ShapeNode>,
+                _synthesisRule as InstrumentedRule<Word, ShapeNode>,
+            };
+        }
+
+        /// <summary>
+        /// Clear all rule statistics.
+        /// </summary>
+        public void ClearRuleStats()
+        {
+            foreach (var rule in GetRuleStats())
+            {
+                rule.ClearStats();
+            }
         }
 
         /// <summary>

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -184,11 +184,16 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// </summary>
         public IEnumerable<InstrumentedRule<Word, ShapeNode>> GetRuleStats()
         {
-            return new List<InstrumentedRule<Word, ShapeNode>>
+            var list = new List<InstrumentedRule<Word, ShapeNode>>();
+            if (_analysisRule is InstrumentedRule<Word, ShapeNode>)
             {
-                _analysisRule as InstrumentedRule<Word, ShapeNode>,
-                _synthesisRule as InstrumentedRule<Word, ShapeNode>,
-            };
+                list.Add(_analysisRule as InstrumentedRule<Word, ShapeNode>);
+            }
+            if (_synthesisRule is InstrumentedRule<Word, ShapeNode>)
+            {
+                list.Add(_synthesisRule as InstrumentedRule<Word, ShapeNode>);
+            }
+            return list;
         }
 
         /// <summary>
@@ -196,7 +201,7 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// </summary>
         public void ClearRuleStats()
         {
-            foreach (var rule in GetRuleStats())
+            foreach (InstrumentedRule<Word, ShapeNode> rule in GetRuleStats())
             {
                 rule.ClearStats();
             }

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -53,6 +53,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
             _analysisRule = lang.CompileAnalysisRule(this);
             _synthesisRule = lang.CompileSynthesisRule(this);
+            ((InstrumentedRule<Word, ShapeNode>)_synthesisRule).Name = "Synthesis";
             MaxStemCount = 2;
             MaxUnapplications = 0;
             MergeEquivalentAnalyses = true;
@@ -119,6 +120,8 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_traceManager.IsTracing)
                 _traceManager.AnalyzeWord(_lang, input);
             trace = input.CurrentTrace;
+            ((InstrumentedRule<Word, ShapeNode>)_analysisRule).ClearStats();
+            ((InstrumentedRule<Word, ShapeNode>)_synthesisRule).ClearStats();
 
             // Unapply rules
             var analyses = new ConcurrentQueue<Word>(_analysisRule.Apply(input));

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisAffixProcessRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisAffixProcessRule.cs
@@ -6,7 +6,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 {
-    public class AnalysisAffixProcessRule : IRule<Word, ShapeNode>
+    public class AnalysisAffixProcessRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly AffixProcessRule _rule;
@@ -14,6 +14,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public AnalysisAffixProcessRule(Morpher morpher, AffixProcessRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -36,7 +37,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             }
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -70,6 +71,8 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 if (_morpher.TraceManager.IsTracing && !unapplied)
                     _morpher.TraceManager.MorphologicalRuleNotUnapplied(_rule, i, input);
             }
+
+            AddRuleStats(output.Count);
             return output;
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisCompoundingRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisCompoundingRule.cs
@@ -35,7 +35,6 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                     )
                 );
             }
-            AddSubRules(_rules);
         }
 
         public override IEnumerable<Word> Apply(Word input)

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisCompoundingRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisCompoundingRule.cs
@@ -6,7 +6,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 {
-    public class AnalysisCompoundingRule : IRule<Word, ShapeNode>
+    public class AnalysisCompoundingRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly CompoundingRule _rule;
@@ -14,6 +14,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public AnalysisCompoundingRule(Morpher morpher, CompoundingRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -34,9 +35,10 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                     )
                 );
             }
+            AddSubRules(_rules);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -143,6 +145,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                     _morpher.TraceManager.MorphologicalRuleNotUnapplied(_rule, i, input);
             }
 
+            AddRuleStats(output.Count);
             return output;
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisRealizationalAffixProcessRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/AnalysisRealizationalAffixProcessRule.cs
@@ -7,7 +7,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 {
-    public class AnalysisRealizationalAffixProcessRule : IRule<Word, ShapeNode>
+    public class AnalysisRealizationalAffixProcessRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly RealizationalAffixProcessRule _rule;
@@ -15,6 +15,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public AnalysisRealizationalAffixProcessRule(Morpher morpher, RealizationalAffixProcessRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -37,7 +38,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             }
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -65,6 +66,8 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 if (_morpher.TraceManager.IsTracing && !unapplied)
                     _morpher.TraceManager.MorphologicalRuleNotUnapplied(_rule, i, input);
             }
+
+            AddRuleStats(output.Count);
             return output;
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisAffixProcessRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisAffixProcessRule.cs
@@ -8,7 +8,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 {
-    public class SynthesisAffixProcessRule : IRule<Word, ShapeNode>
+    public class SynthesisAffixProcessRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly AffixProcessRule _rule;
@@ -16,6 +16,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public SynthesisAffixProcessRule(Morpher morpher, AffixProcessRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
             _rules = new List<PatternRule<Word, ShapeNode>>();
@@ -38,7 +39,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             }
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!input.IsMorphologicalRuleApplicable(_rule))
                 return Enumerable.Empty<Word>();
@@ -232,6 +233,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 }
             }
 
+            AddRuleStats(output.Count);
             return output;
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisCompoundingRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisCompoundingRule.cs
@@ -9,7 +9,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 {
-    public class SynthesisCompoundingRule : IRule<Word, ShapeNode>
+    public class SynthesisCompoundingRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly CompoundingRule _rule;
@@ -17,6 +17,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public SynthesisCompoundingRule(Morpher morpher, CompoundingRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
             _subruleMatchers = new List<Tuple<Matcher<Word, ShapeNode>, Matcher<Word, ShapeNode>>>();
@@ -42,7 +43,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             );
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!input.IsMorphologicalRuleApplicable(_rule))
                 return Enumerable.Empty<Word>();
@@ -223,6 +224,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 }
             }
 
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisRealizationalAffixProcessRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisRealizationalAffixProcessRule.cs
@@ -9,7 +9,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 {
-    public class SynthesisRealizationalAffixProcessRule : IRule<Word, ShapeNode>
+    public class SynthesisRealizationalAffixProcessRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly RealizationalAffixProcessRule _rule;
@@ -17,6 +17,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public SynthesisRealizationalAffixProcessRule(Morpher morpher, RealizationalAffixProcessRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
             _rules = new List<PatternRule<Word, ShapeNode>>();
@@ -38,7 +39,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             }
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -162,6 +163,7 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
                 }
             }
 
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRule.cs
@@ -8,7 +8,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 {
-    public class AnalysisMetathesisRule : IRule<Word, ShapeNode>
+    public class AnalysisMetathesisRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly MetathesisRule _rule;
@@ -16,6 +16,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 
         public AnalysisMetathesisRule(Morpher morpher, MetathesisRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -35,7 +36,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             _patternRule = new IterativePhonologicalPatternRule(ruleSpec, settings);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -48,7 +49,11 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             {
                 if (_morpher.TraceManager.IsTracing)
                     _morpher.TraceManager.PhonologicalRuleUnapplied(_rule, -1, origInput, input);
-                return input.ToEnumerable();
+                {
+                    IEnumerable<Word> output = input.ToEnumerable();
+                    AddRuleStats(output.Count());
+                    return output;
+                }
             }
 
             if (_morpher.TraceManager.IsTracing)

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisRewriteRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisRewriteRule.cs
@@ -10,7 +10,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 {
-    public class AnalysisRewriteRule : IRule<Word, ShapeNode>
+    public class AnalysisRewriteRule : InstrumentedRule<Word, ShapeNode>
     {
         private enum ReapplyType
         {
@@ -25,6 +25,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 
         public AnalysisRewriteRule(Morpher morpher, RewriteRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -125,7 +126,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             return true;
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -188,7 +189,11 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             }
 
             if (applied)
-                return input.ToEnumerable();
+            {
+                IEnumerable<Word> output = input.ToEnumerable();
+                AddRuleStats(output.Count());
+                return output;
+            }
             return Enumerable.Empty<Word>();
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRule.cs
@@ -7,7 +7,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 {
-    public class SynthesisMetathesisRule : IRule<Word, ShapeNode>
+    public class SynthesisMetathesisRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly MetathesisRule _rule;
@@ -15,6 +15,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 
         public SynthesisMetathesisRule(Morpher morpher, MetathesisRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -32,7 +33,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             _patternRule = new IterativePhonologicalPatternRule(ruleSpec, settings);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -45,7 +46,9 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             {
                 if (_morpher.TraceManager.IsTracing)
                     _morpher.TraceManager.PhonologicalRuleApplied(_rule, -1, origInput, input);
-                return input.ToEnumerable();
+                IEnumerable<Word> output = input.ToEnumerable();
+                AddRuleStats(output.Count());
+                return output;
             }
 
             if (_morpher.TraceManager.IsTracing)

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisRewriteRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisRewriteRule.cs
@@ -8,7 +8,7 @@ using SIL.Machine.Rules;
 
 namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 {
-    public class SynthesisRewriteRule : IRule<Word, ShapeNode>
+    public class SynthesisRewriteRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly RewriteRule _rule;
@@ -16,6 +16,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
 
         public SynthesisRewriteRule(Morpher morpher, RewriteRule rule)
         {
+            Name = rule.Name;
             _morpher = morpher;
             _rule = rule;
 
@@ -48,7 +49,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             }
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
@@ -84,7 +85,11 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
                 input.CurrentRuleResults = null;
             }
             if (applied)
-                return input.ToEnumerable();
+            {
+                IEnumerable<Word> output = input.ToEnumerable();
+                AddRuleStats(output.Count());
+                return output;
+            }
             return Enumerable.Empty<Word>();
         }
     }

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisAffixTemplateRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisAffixTemplateRule.cs
@@ -6,7 +6,7 @@ using SIL.ObjectModel;
 
 namespace SIL.Machine.Morphology.HermitCrab
 {
-    internal class SynthesisAffixTemplateRule : IRule<Word, ShapeNode>
+    internal class SynthesisAffixTemplateRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly AffixTemplate _template;
@@ -14,6 +14,7 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public SynthesisAffixTemplateRule(Morpher morpher, AffixTemplate template)
         {
+            Name = template.Name;
             _morpher = morpher;
             _template = template;
             _rules = new List<IRule<Word, ShapeNode>>(
@@ -23,14 +24,16 @@ namespace SIL.Machine.Morphology.HermitCrab
                     FreezableEqualityComparer<Word>.Default
                 ))
             );
+            AddSubRules(_rules);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (_morpher.TraceManager.IsTracing)
                 _morpher.TraceManager.BeginApplyTemplate(_template, input);
             var output = new HashSet<Word>(FreezableEqualityComparer<Word>.Default);
             ApplySlots(input, 0, output);
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisAffixTemplatesRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisAffixTemplatesRule.cs
@@ -7,7 +7,7 @@ using SIL.ObjectModel;
 
 namespace SIL.Machine.Morphology.HermitCrab
 {
-    internal class SynthesisAffixTemplatesRule : IRule<Word, ShapeNode>
+    internal class SynthesisAffixTemplatesRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly Morpher _morpher;
         private readonly Stratum _stratum;
@@ -16,13 +16,15 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public SynthesisAffixTemplatesRule(Morpher morpher, Stratum stratum)
         {
+            Name = stratum.Name;
             _morpher = morpher;
             _stratum = stratum;
             _templates = stratum.AffixTemplates.ToList();
             _templateRules = _templates.Select(temp => temp.CompileSynthesisRule(morpher)).ToList();
+            AddSubRules(_templateRules);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!input.RealizationalFeatureStruct.IsUnifiable(input.SyntacticFeatureStruct))
                 return Enumerable.Empty<Word>();
@@ -74,6 +76,7 @@ namespace SIL.Machine.Morphology.HermitCrab
                 }
             }
 
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisStratumRule.cs
@@ -95,7 +95,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_morpher.TraceManager.IsTracing && output.Count == 0)
                 _morpher.TraceManager.EndApplyStratum(_stratum, input);
 
-            ElapsedTime += Stopwatch.GetTimestamp() - startTime;
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(output.Count);
             return output;
         }

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisStratumRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisStratumRule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using SIL.Extensions;
 using SIL.Machine.Annotations;
@@ -7,7 +8,7 @@ using SIL.ObjectModel;
 
 namespace SIL.Machine.Morphology.HermitCrab
 {
-    internal class SynthesisStratumRule : IRule<Word, ShapeNode>
+    internal class SynthesisStratumRule : InstrumentedRule<Word, ShapeNode>
     {
         private readonly IRule<Word, ShapeNode> _mrulesRule;
         private readonly IRule<Word, ShapeNode> _prulesRule;
@@ -17,6 +18,7 @@ namespace SIL.Machine.Morphology.HermitCrab
 
         public SynthesisStratumRule(Morpher morpher, Stratum stratum)
         {
+            Name = stratum.Name;
             _templatesRule = new SynthesisAffixTemplatesRule(morpher, stratum);
             _mrulesRule = null;
             IEnumerable<IRule<Word, ShapeNode>> mrules = stratum.MorphologicalRules.Select(mrule =>
@@ -44,9 +46,12 @@ namespace SIL.Machine.Morphology.HermitCrab
             );
             _stratum = stratum;
             _morpher = morpher;
+            AddSubRule(_mrulesRule);
+            AddSubRule(_prulesRule);
+            AddSubRule(_templatesRule);
         }
 
-        public IEnumerable<Word> Apply(Word input)
+        public override IEnumerable<Word> Apply(Word input)
         {
             if (!_morpher.RuleSelector(_stratum) || input.RootAllomorph.Morpheme.Stratum.Depth > _stratum.Depth)
                 return input.ToEnumerable();
@@ -54,6 +59,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             if (_morpher.TraceManager.IsTracing)
                 _morpher.TraceManager.BeginApplyStratum(_stratum, input);
 
+            long startTime = Stopwatch.GetTimestamp();
             var output = new HashSet<Word>(FreezableEqualityComparer<Word>.Default);
             foreach (Word mruleOutWord in ApplyMorphologicalRules(input).Concat(ApplyTemplates(input)))
             {
@@ -88,6 +94,9 @@ namespace SIL.Machine.Morphology.HermitCrab
             }
             if (_morpher.TraceManager.IsTracing && output.Count == 0)
                 _morpher.TraceManager.EndApplyStratum(_stratum, input);
+
+            ElapsedTime += Stopwatch.GetTimestamp() - startTime;
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine/Rules/CombinationRuleCascade.cs
+++ b/src/SIL.Machine/Rules/CombinationRuleCascade.cs
@@ -26,6 +26,7 @@ namespace SIL.Machine.Rules
         {
             var output = new HashSet<TData>(Comparer);
             ApplyRules(input, !MultipleApplication ? new HashSet<int>() : null, output);
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine/Rules/CombinationRuleCascade.cs
+++ b/src/SIL.Machine/Rules/CombinationRuleCascade.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
@@ -24,8 +25,10 @@ namespace SIL.Machine.Rules
 
         public override IEnumerable<TData> Apply(TData input)
         {
+            long startTime = Stopwatch.GetTimestamp();
             var output = new HashSet<TData>(Comparer);
             ApplyRules(input, !MultipleApplication ? new HashSet<int>() : null, output);
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(output.Count);
             return output;
         }

--- a/src/SIL.Machine/Rules/InstrumentedRule.cs
+++ b/src/SIL.Machine/Rules/InstrumentedRule.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
@@ -20,6 +21,7 @@ namespace SIL.Machine.Rules
         public int OutputCount;
         public long ElapsedTime;
         public IList<InstrumentedRule<TData, TOffset>> SubRules = new List<InstrumentedRule<TData, TOffset>>();
+        private readonly object _lock = new object();
 
         public InstrumentedRule() { }
 
@@ -47,8 +49,8 @@ namespace SIL.Machine.Rules
         {
             if (outputCount > 0)
             {
-                InputCount++;
-                OutputCount += outputCount;
+                Interlocked.Increment(ref InputCount);
+                Interlocked.Add(ref OutputCount, outputCount);
             }
         }
 
@@ -57,7 +59,10 @@ namespace SIL.Machine.Rules
         /// </summary>
         protected void AddElapsedTime(long elapsedTime)
         {
-            ElapsedTime += elapsedTime;
+            lock (_lock)
+            {
+                ElapsedTime += elapsedTime;
+            }
         }
 
         /// <summary>

--- a/src/SIL.Machine/Rules/InstrumentedRule.cs
+++ b/src/SIL.Machine/Rules/InstrumentedRule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
@@ -11,7 +12,7 @@ namespace SIL.Machine.Rules
     /// </summary>
     /// <typeparam name="TData"></typeparam>
     /// <typeparam name="TOffset"></typeparam>
-    public abstract class InstrumentedRule<TData, TOffset>: IRule<TData, TOffset>
+    public abstract class InstrumentedRule<TData, TOffset> : IRule<TData, TOffset>
         where TData : IAnnotatedData<TOffset>
     {
         public string Name { get; set; }
@@ -22,6 +23,10 @@ namespace SIL.Machine.Rules
 
         public InstrumentedRule() { }
 
+        /// <summary>
+        /// Add sub-rules to the rule statisics.
+        /// </summary>
+        /// <param name="rules"></param>
         protected void AddSubRules(IEnumerable<IRule<TData, TOffset>> rules)
         {
             foreach (IRule<TData, TOffset> rule in rules)
@@ -30,23 +35,52 @@ namespace SIL.Machine.Rules
             }
         }
 
-        protected void AddSubRule(IRule<TData, TOffset>rule)
+        protected void AddSubRule(IRule<TData, TOffset> rule)
         {
             SubRules.Add(rule as InstrumentedRule<TData, TOffset>);
         }
 
+        /// <summary>
+        /// Add input count and output count to the rule statistics.
+        /// </summary>
         protected void AddRuleStats(int outputCount)
         {
-            InputCount++;
-            OutputCount += outputCount;
+            if (outputCount > 0)
+            {
+                InputCount++;
+                OutputCount += outputCount;
+            }
         }
 
+        /// <summary>
+        /// Add elapsed time to the rule statistics.
+        /// </summary>
+        protected void AddElapsedTime(long elapsedTime)
+        {
+            ElapsedTime += elapsedTime;
+        }
+
+        /// <summary>
+        /// Sort SubRules unless the order matters.
+        /// </summary>
+        public void SortSubRules()
+        {
+            if (Name == "Analysis" || Name == "Synthesis" || Name == "RuleCascade")
+            {
+                return;
+            }
+            SubRules = SubRules.OrderByDescending(rule => rule.OutputCount).ToList();
+        }
+
+        /// <summary>
+        /// Clear all rule statistics.
+        /// </summary>
         public void ClearStats()
         {
             InputCount = 0;
             OutputCount = 0;
             ElapsedTime = 0;
-            foreach (var rule in SubRules)
+            foreach (InstrumentedRule<TData, TOffset> rule in SubRules)
             {
                 rule.ClearStats();
             }

--- a/src/SIL.Machine/Rules/InstrumentedRule.cs
+++ b/src/SIL.Machine/Rules/InstrumentedRule.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using SIL.Machine.Annotations;
+
+namespace SIL.Machine.Rules
+{
+    /// <summary>
+    /// This class instruments IRules.
+    /// Statistics are stored in InputCount, OutputCount, and ElapsedTime.
+    /// The rules update the statistics when Apply is called.
+    /// Name and SubRules are filled in when the rule is created.
+    /// </summary>
+    /// <typeparam name="TData"></typeparam>
+    /// <typeparam name="TOffset"></typeparam>
+    public abstract class InstrumentedRule<TData, TOffset>: IRule<TData, TOffset>
+        where TData : IAnnotatedData<TOffset>
+    {
+        public string Name { get; set; }
+        public int InputCount;
+        public int OutputCount;
+        public long ElapsedTime;
+        public IList<InstrumentedRule<TData, TOffset>> SubRules = new List<InstrumentedRule<TData, TOffset>>();
+
+        public InstrumentedRule() { }
+
+        protected void AddSubRules(IEnumerable<IRule<TData, TOffset>> rules)
+        {
+            foreach (IRule<TData, TOffset> rule in rules)
+            {
+                AddSubRule(rule);
+            }
+        }
+
+        protected void AddSubRule(IRule<TData, TOffset>rule)
+        {
+            SubRules.Add(rule as InstrumentedRule<TData, TOffset>);
+        }
+
+        protected void AddRuleStats(int outputCount)
+        {
+            InputCount++;
+            OutputCount += outputCount;
+        }
+
+        public void ClearStats()
+        {
+            InputCount = 0;
+            OutputCount = 0;
+            ElapsedTime = 0;
+            foreach (var rule in SubRules)
+            {
+                rule.ClearStats();
+            }
+        }
+
+        public abstract IEnumerable<TData> Apply(TData input);
+    }
+}

--- a/src/SIL.Machine/Rules/LinearRuleCascade.cs
+++ b/src/SIL.Machine/Rules/LinearRuleCascade.cs
@@ -26,6 +26,7 @@ namespace SIL.Machine.Rules
         {
             var output = new HashSet<TData>(Comparer);
             ApplyRules(input, 0, output);
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine/Rules/LinearRuleCascade.cs
+++ b/src/SIL.Machine/Rules/LinearRuleCascade.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
@@ -24,8 +25,10 @@ namespace SIL.Machine.Rules
 
         public override IEnumerable<TData> Apply(TData input)
         {
+            long startTime = Stopwatch.GetTimestamp();
             var output = new HashSet<TData>(Comparer);
             ApplyRules(input, 0, output);
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(output.Count);
             return output;
         }

--- a/src/SIL.Machine/Rules/ParallelRuleBatch.cs
+++ b/src/SIL.Machine/Rules/ParallelRuleBatch.cs
@@ -28,7 +28,9 @@ namespace SIL.Machine.Rules
                 }
             );
 
-            return output.Distinct(Comparer);
+            IEnumerable<TData> distinctOutput = output.Distinct(Comparer);
+            AddRuleStats(distinctOutput.Count());
+            return distinctOutput;
         }
     }
 }

--- a/src/SIL.Machine/Rules/PermutationRuleCascade.cs
+++ b/src/SIL.Machine/Rules/PermutationRuleCascade.cs
@@ -26,6 +26,7 @@ namespace SIL.Machine.Rules
         {
             var output = new HashSet<TData>(Comparer);
             ApplyRules(input, 0, output);
+            AddRuleStats(output.Count);
             return output;
         }
 

--- a/src/SIL.Machine/Rules/PermutationRuleCascade.cs
+++ b/src/SIL.Machine/Rules/PermutationRuleCascade.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
@@ -24,8 +25,10 @@ namespace SIL.Machine.Rules
 
         public override IEnumerable<TData> Apply(TData input)
         {
+            long startTime = Stopwatch.GetTimestamp();
             var output = new HashSet<TData>(Comparer);
             ApplyRules(input, 0, output);
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(output.Count);
             return output;
         }

--- a/src/SIL.Machine/Rules/PipelineRuleCascade.cs
+++ b/src/SIL.Machine/Rules/PipelineRuleCascade.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
@@ -14,6 +15,7 @@ namespace SIL.Machine.Rules
 
         public override IEnumerable<TData> Apply(TData input)
         {
+            long startTime = Stopwatch.GetTimestamp();
             var inputSet = new HashSet<TData>(Comparer) { input };
             HashSet<TData> outputSet = null;
             var tempSet = new HashSet<TData>(Comparer);
@@ -29,6 +31,7 @@ namespace SIL.Machine.Rules
                 inputSet = outputSet;
             }
 
+            AddElapsedTime(Stopwatch.GetTimestamp() - startTime);
             AddRuleStats(outputSet.Count);
             return outputSet;
         }

--- a/src/SIL.Machine/Rules/PipelineRuleCascade.cs
+++ b/src/SIL.Machine/Rules/PipelineRuleCascade.cs
@@ -29,6 +29,7 @@ namespace SIL.Machine.Rules
                 inputSet = outputSet;
             }
 
+            AddRuleStats(outputSet.Count);
             return outputSet;
         }
     }

--- a/src/SIL.Machine/Rules/RuleBatch.cs
+++ b/src/SIL.Machine/Rules/RuleBatch.cs
@@ -4,7 +4,7 @@ using SIL.Machine.Annotations;
 
 namespace SIL.Machine.Rules
 {
-    public class RuleBatch<TData, TOffset> : IRule<TData, TOffset>
+    public class RuleBatch<TData, TOffset> : InstrumentedRule<TData, TOffset>
         where TData : IAnnotatedData<TOffset>
     {
         private readonly List<IRule<TData, TOffset>> _rules;
@@ -22,9 +22,11 @@ namespace SIL.Machine.Rules
 
         public RuleBatch(IEnumerable<IRule<TData, TOffset>> rules, bool disjunctive, IEqualityComparer<TData> comparer)
         {
+            Name = "RuleBatch";
             _rules = new List<IRule<TData, TOffset>>(rules);
             _disjunctive = disjunctive;
             _comparer = comparer;
+            AddSubRules(_rules);
         }
 
         public IReadOnlyList<IRule<TData, TOffset>> Rules
@@ -42,7 +44,7 @@ namespace SIL.Machine.Rules
             get { return _disjunctive; }
         }
 
-        public virtual IEnumerable<TData> Apply(TData input)
+        public override IEnumerable<TData> Apply(TData input)
         {
             var output = new HashSet<TData>(_comparer);
             foreach (IRule<TData, TOffset> rule in _rules)
@@ -52,6 +54,7 @@ namespace SIL.Machine.Rules
                     return output;
             }
 
+            AddRuleStats(output.Count);
             return output;
         }
     }

--- a/src/SIL.Machine/Rules/RuleCascade.cs
+++ b/src/SIL.Machine/Rules/RuleCascade.cs
@@ -5,7 +5,7 @@ using SIL.ObjectModel;
 
 namespace SIL.Machine.Rules
 {
-    public abstract class RuleCascade<TData, TOffset> : IRule<TData, TOffset>
+    public abstract class RuleCascade<TData, TOffset> : InstrumentedRule<TData, TOffset>
         where TData : IAnnotatedData<TOffset>
     {
         private readonly ReadOnlyList<IRule<TData, TOffset>> _rules;
@@ -27,9 +27,11 @@ namespace SIL.Machine.Rules
             IEqualityComparer<TData> comparer
         )
         {
+            Name = "RuleCascade";
             _rules = new ReadOnlyList<IRule<TData, TOffset>>(rules.ToList());
             _multiApp = multiApp;
             _comparer = comparer;
+            AddSubRules(_rules);
         }
 
         public IEqualityComparer<TData> Comparer
@@ -47,7 +49,7 @@ namespace SIL.Machine.Rules
             get { return _rules; }
         }
 
-        public abstract IEnumerable<TData> Apply(TData input);
+        public abstract override IEnumerable<TData> Apply(TData input);
 
         protected virtual IEnumerable<TData> ApplyRule(IRule<TData, TOffset> rule, int index, TData input)
         {


### PR DESCRIPTION
Adds code to instrument rule applications by creating an InstrumentedRule class for the rules that should be instrumented.  Changes the code for creating rule classes to record data needed for instrumentation.  Changes the Apply functions to collect statistics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/449)
<!-- Reviewable:end -->
