### PR TITLE
LT-22613: fix analysis-length bound over-pruning for count-mismatched rewrite subrules

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/AnalysisStateKey.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/AnalysisStateKey.cs
@@ -87,10 +87,7 @@ namespace SIL.Machine.Morphology.HermitCrab
                 return false;
             if (!_shape.ValueEquals(other._shape))
                 return false;
-            if (
-                !_syntacticFS.ValueEquals(other._syntacticFS)
-                || !_realizationalFS.ValueEquals(other._realizationalFS)
-            )
+            if (!_syntacticFS.ValueEquals(other._syntacticFS) || !_realizationalFS.ValueEquals(other._realizationalFS))
                 return false;
             return RuleCountsEqual(_ruleCounts, other._ruleCounts);
         }

--- a/src/SIL.Machine.Morphology.HermitCrab/GrammarAnalyzer.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/GrammarAnalyzer.cs
@@ -12,17 +12,16 @@ namespace SIL.Machine.Morphology.HermitCrab
     /// "Gate B" -- Gate A, a mirror-image synthesis-side bound, was attempted and reverted; see the note
     /// in <see cref="Morpher.SynthesizeAnalysis"/>). The bound is a deliberately loose over-approximation
     /// -- summed across every rule's own already-declared reapplication limit
-    /// (<see cref="Morphology.HermitCrab.MorphologicalRules.AffixProcessRule.MaxApplicationCount"/>,
-    /// <see cref="Morpher.DeletionReapplications"/>), never estimated -- so it can prune a candidate only
-    /// when NO combination of rules in the grammar could ever produce something that long, regardless of
-    /// which specific root or derivation path is under consideration. Returns null (meaning "no admissible
-    /// bound, gate off") the moment any rule's shape falls outside what this class knows how to measure
-    /// exactly (quantifiers/groups/alternations in a phonological Lhs/Rhs, an insertion-type rewrite
-    /// subrule -- epenthesis/expansion, whose unapplication marks surface segments optional instead of
-    /// removing them, so the running shape length stops bounding the underlying length; see LT-22613 --
-    /// or a compounding rule present at all, since compounding combines multiple full root lengths rather
-    /// than adding a bounded affix) -- per the plan's own rule: skipping only costs pruning opportunity,
-    /// an admissible bound must never be guessed.
+    /// (<see cref="Morphology.HermitCrab.MorphologicalRules.AffixProcessRule.MaxApplicationCount"/>),
+    /// never estimated -- so it can prune a candidate only when NO combination of rules in the grammar
+    /// could ever produce something that long, regardless of which specific root or derivation path is
+    /// under consideration. Returns null (meaning "no admissible bound, gate off") the moment any rule's
+    /// shape falls outside what this class knows how to measure exactly (quantifiers/groups/alternations
+    /// in a phonological Lhs/Rhs, any phonological rewrite subrule whose Lhs and Rhs segment counts differ
+    /// -- see LT-22613, and the remarks on <see cref="TryGetFlatSegmentCount"/>'s caller below -- or a
+    /// compounding rule present at all, since compounding combines multiple full root lengths rather than
+    /// adding a bounded affix) -- per the plan's own rule: skipping only costs pruning opportunity, an
+    /// admissible bound must never be guessed.
     /// </summary>
     public static class GrammarAnalyzer
     {
@@ -31,23 +30,25 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// represent: the longest root allomorph in the lexicon, plus every affix/realizational rule's own
         /// maximum possible net insertion (its allomorphs' <see cref="InsertSegments"/>/
         /// <see cref="InsertSimpleContext"/> actions, summed and multiplied by
-        /// <see cref="Morphology.HermitCrab.MorphologicalRules.AffixProcessRule.MaxApplicationCount"/>),
-        /// plus every phonological deletion-type subrule's maximum possible net restoration. Null if any
-        /// rule in the grammar can't be measured this way (see class remarks).
+        /// <see cref="Morphology.HermitCrab.MorphologicalRules.AffixProcessRule.MaxApplicationCount"/>).
+        /// Null if any rule in the grammar can't be measured this way (see class remarks) -- in
+        /// particular, every phonological rewrite subrule in the grammar must leave Lhs and Rhs segment
+        /// counts equal (a pure feature-changing rule, handled analysis-side by
+        /// <c>FeatureAnalysisRewriteRuleSpec</c>, which mutates matched segments in place and never
+        /// changes the shape's length). Any subrule where they differ -- epenthesis/expansion (Rhs longer)
+        /// or deletion/coalescence (Lhs longer) alike -- is unapplied analysis-side by
+        /// <c>EpenthesisAnalysisRewriteRuleSpec</c>/<c>NarrowAnalysisRewriteRuleSpec</c>, both of which
+        /// grow the candidate shape by inserting <c>Lhs.Count</c> new (Optional, not Deleted) nodes per
+        /// match site regardless of <c>Rhs.Count</c>, while leaving the matched Rhs-shaped region in place
+        /// (also not Deleted). <see cref="HermitCrabExtensions.SegmentCount"/> counts every non-Deleted
+        /// segment, so real per-site growth is always exactly <c>Lhs.Count</c> -- never the naively
+        /// expected <c>Lhs.Count - Rhs.Count</c>, which undercounts by <c>Rhs.Count</c> whenever
+        /// <c>Rhs.Count &gt; 0</c> (LT-22613: first found via epenthesis pruning a valid analysis as
+        /// "too long" on the default non-tracing path while the tracing path, which bypasses this gate,
+        /// parsed it correctly; the same undercount also applies to ordinary deletion/coalescence rules,
+        /// which is why the bail-out is on any count mismatch, not just Rhs longer than Lhs).
         /// </summary>
-        /// <remarks>
-        /// The phonological term is compounding, not additive: <c>AnalysisRewriteRule</c>'s Deletion
-        /// reapply loop runs <see cref="Morpher.DeletionReapplications"/> + 1 passes, and each pass is a
-        /// <c>SimultaneousPhonologicalPatternRule</c> sweep that can restore EVERY non-overlapping match
-        /// site in the current shape at once, not just one -- a real case (<c>RewriteRuleTests
-        /// .MultipleDeletionRules</c>: an 8-segment root deletes two independent "ii" clusters down to a
-        /// 4-segment surface form in one pass) needs more than "count of subrules" restored segments per
-        /// pass. Bounding the number of sites by the current running length (itself already an
-        /// over-approximation of the true pre-phonology length at this point) keeps this sound: real growth
-        /// can never exceed <c>runningLength * subruleDelta</c> per pass, since a simultaneous sweep cannot
-        /// match more sites than there are segments to match against.
-        /// </remarks>
-        public static int? ComputeMaxAnalysisLength(Language language, int deletionReapplications)
+        public static int? ComputeMaxAnalysisLength(Language language)
         {
             int bound = 0;
             foreach (Stratum stratum in language.Strata)
@@ -66,7 +67,6 @@ namespace SIL.Machine.Morphology.HermitCrab
                 )
                     bound += MaxAllomorphInsertion(rule.Allomorphs);
 
-                int phonoGrowthRate = 0;
                 foreach (RewriteRule rule in stratum.PhonologicalRules.OfType<RewriteRule>())
                 {
                     if (!TryGetFlatSegmentCount(rule.Lhs, out int lhsCount))
@@ -75,26 +75,13 @@ namespace SIL.Machine.Morphology.HermitCrab
                     {
                         if (!TryGetFlatSegmentCount(sr.Rhs, out int rhsCount))
                             return null;
-                        // Insertion-type subrule (epenthesis when Lhs is empty, expansion otherwise):
-                        // no admissible bound (LT-22613). Unlike every other unapplication this class
-                        // reasons about, insertion unapplication does not SHRINK the candidate -- it
-                        // marks the possibly-rule-inserted surface segments Optional and leaves them in
-                        // the shape (EpenthesisAnalysisRewriteRuleSpec.Unapply /
-                        // NarrowAnalysisRewriteRuleSpec.Unapply), and lexical lookup later matches with
-                        // those segments skipped. AnalysisStratumRule's gate measures the candidate with
-                        // Shape.SegmentCount, which still counts them, so a surface form that legally
-                        // outgrew the longest root via epenthesis (e.g. "buibui" from root "b+ubu")
-                        // would be pruned as unreachable on the default, non-tracing path while the
-                        // traced path -- which bypasses the gate -- parses it correctly. Per this
-                        // class's ground rule, that means return null (gate off), never guess.
-                        if (lhsCount < rhsCount)
+                        // Any subrule where Lhs and Rhs segment counts differ: no admissible bound
+                        // (LT-22613; see this method's doc comment for the full mechanism). Only a
+                        // count-preserving (pure feature-changing) subrule is safe to ignore here.
+                        if (lhsCount != rhsCount)
                             return null;
-                        if (lhsCount > rhsCount)
-                            phonoGrowthRate += lhsCount - rhsCount;
                     }
                 }
-                for (int pass = 0; pass < deletionReapplications + 1 && phonoGrowthRate > 0; pass++)
-                    bound += bound * phonoGrowthRate;
             }
             return bound;
         }

--- a/src/SIL.Machine.Morphology.HermitCrab/GrammarAnalyzer.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/GrammarAnalyzer.cs
@@ -56,7 +56,11 @@ namespace SIL.Machine.Morphology.HermitCrab
                 if (stratum.MorphologicalRules.OfType<CompoundingRule>().Any())
                     return null;
 
-                int longestRoot = stratum.Entries.SelectMany(e => e.Allomorphs).Select(SegmentCount).DefaultIfEmpty(0).Max();
+                int longestRoot = stratum
+                    .Entries.SelectMany(e => e.Allomorphs)
+                    .Select(SegmentCount)
+                    .DefaultIfEmpty(0)
+                    .Max();
                 bound += longestRoot;
 
                 foreach (AffixProcessRule rule in stratum.MorphologicalRules.OfType<AffixProcessRule>())

--- a/src/SIL.Machine.Morphology.HermitCrab/GrammarAnalyzer.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/GrammarAnalyzer.cs
@@ -17,10 +17,12 @@ namespace SIL.Machine.Morphology.HermitCrab
     /// when NO combination of rules in the grammar could ever produce something that long, regardless of
     /// which specific root or derivation path is under consideration. Returns null (meaning "no admissible
     /// bound, gate off") the moment any rule's shape falls outside what this class knows how to measure
-    /// exactly (quantifiers/groups/alternations in a phonological Lhs/Rhs, or a compounding rule present
-    /// at all, since compounding combines multiple full root lengths rather than adding a bounded affix)
-    /// -- per the plan's own rule: skipping only costs pruning opportunity, an admissible bound must never
-    /// be guessed.
+    /// exactly (quantifiers/groups/alternations in a phonological Lhs/Rhs, an insertion-type rewrite
+    /// subrule -- epenthesis/expansion, whose unapplication marks surface segments optional instead of
+    /// removing them, so the running shape length stops bounding the underlying length; see LT-22613 --
+    /// or a compounding rule present at all, since compounding combines multiple full root lengths rather
+    /// than adding a bounded affix) -- per the plan's own rule: skipping only costs pruning opportunity,
+    /// an admissible bound must never be guessed.
     /// </summary>
     public static class GrammarAnalyzer
     {
@@ -72,6 +74,20 @@ namespace SIL.Machine.Morphology.HermitCrab
                     foreach (RewriteSubrule sr in rule.Subrules)
                     {
                         if (!TryGetFlatSegmentCount(sr.Rhs, out int rhsCount))
+                            return null;
+                        // Insertion-type subrule (epenthesis when Lhs is empty, expansion otherwise):
+                        // no admissible bound (LT-22613). Unlike every other unapplication this class
+                        // reasons about, insertion unapplication does not SHRINK the candidate -- it
+                        // marks the possibly-rule-inserted surface segments Optional and leaves them in
+                        // the shape (EpenthesisAnalysisRewriteRuleSpec.Unapply /
+                        // NarrowAnalysisRewriteRuleSpec.Unapply), and lexical lookup later matches with
+                        // those segments skipped. AnalysisStratumRule's gate measures the candidate with
+                        // Shape.SegmentCount, which still counts them, so a surface form that legally
+                        // outgrew the longest root via epenthesis (e.g. "buibui" from root "b+ubu")
+                        // would be pruned as unreachable on the default, non-tracing path while the
+                        // traced path -- which bypasses the gate -- parses it correctly. Per this
+                        // class's ground rule, that means return null (gate off), never guess.
+                        if (lhsCount < rhsCount)
                             return null;
                         if (lhsCount > rhsCount)
                             phonoGrowthRate += lhsCount - rhsCount;

--- a/src/SIL.Machine.Morphology.HermitCrab/MemoizedCombinationRuleCascade.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MemoizedCombinationRuleCascade.cs
@@ -75,7 +75,11 @@ namespace SIL.Machine.Morphology.HermitCrab
                 var replayed = new List<Word>(entry.Results.Count);
                 foreach (Word storedResult in entry.Results)
                 {
-                    Word replay = storedResult.ReplayOnto(input, entry.MruleTrailPrefixLength, entry.NonHeadPrefixLength);
+                    Word replay = storedResult.ReplayOnto(
+                        input,
+                        entry.MruleTrailPrefixLength,
+                        entry.NonHeadPrefixLength
+                    );
                     output.Add(replay);
                     replayed.Add(replay);
                 }

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -130,10 +130,10 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// "Gate B") -- auto-derived from the grammar (<see cref="GrammarAnalyzer.ComputeMaxAnalysisLength"/>:
         /// the longest lexicon root plus every rule's own maximum possible insertion) unless explicitly set.
         /// Setting this (including to <c>null</c>, which disables the gate entirely) overrides the
-        /// auto-derived value; re-derived fresh from the current grammar and <see cref="DeletionReapplications"/>
-        /// on every read otherwise, so it never goes stale if either changes after construction. Auto-derives
-        /// to <c>null</c> (gate off) when the grammar contains a compounding rule or a phonological rule shape
-        /// this analysis can't measure exactly -- see <see cref="GrammarAnalyzer"/>'s remarks.
+        /// auto-derived value; re-derived fresh from the current grammar on every read otherwise, so it
+        /// never goes stale if the grammar changes after construction. Auto-derives to <c>null</c> (gate
+        /// off) when the grammar contains a compounding rule or a phonological rule shape this analysis
+        /// can't measure exactly -- see <see cref="GrammarAnalyzer"/>'s remarks.
         /// </summary>
         public int? MaxAnalysisLength
         {
@@ -141,7 +141,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             {
                 return _maxAnalysisLengthOverrideSet
                     ? _maxAnalysisLengthOverride
-                    : GrammarAnalyzer.ComputeMaxAnalysisLength(_lang, DeletionReapplications);
+                    : GrammarAnalyzer.ComputeMaxAnalysisLength(_lang);
             }
             set
             {

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
@@ -852,4 +852,39 @@ public class MorpherTests : HermitCrabTestBase
             Allophonic.MorphologicalRules.Remove(infix);
         }
     }
+
+    [Test]
+    public void ComputeMaxAnalysisLength_ReturnsNull_ForInsertionRewriteRule()
+    {
+        // LT-22613: an insertion-type rewrite subrule (Rhs longer than Lhs -- epenthesis when Lhs is
+        // empty) makes the analysis length bound inadmissible: its unapplication marks the inserted
+        // surface segments OPTIONAL rather than removing them (EpenthesisAnalysisRewriteRuleSpec/
+        // NarrowAnalysisRewriteRuleSpec), so a candidate's segment count at AnalysisStratumRule's gate
+        // no longer bounds the underlying length the candidate could still justify. Per this class's
+        // own ground rule, that means "no admissible bound" (null, gate off), not a guessed bound.
+        var highVowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Symbol("high+")
+            .Value;
+        var epenthesis = new RewriteRule { Name = "epenthesis", ApplicationMode = RewriteApplicationMode.Simultaneous };
+        epenthesis.Subrules.Add(
+            new RewriteSubrule
+            {
+                Rhs = Pattern<Word, int>.New().Annotation(highVowel).Value,
+                LeftEnvironment = Pattern<Word, int>.New().Annotation(highVowel).Value,
+            }
+        );
+        Allophonic.PhonologicalRules.Add(epenthesis);
+        try
+        {
+            Assert.That(GrammarAnalyzer.ComputeMaxAnalysisLength(Language, 0), Is.Null);
+        }
+        finally
+        {
+            Allophonic.PhonologicalRules.Remove(epenthesis);
+        }
+    }
 }

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
@@ -775,9 +775,7 @@ public class MorpherTests : HermitCrabTestBase
                 List<Word> onResult = gateOn.ParseWord(word).ToList();
                 Assert.That(
                     onResult.Select(WordResultSignature).OrderBy(s => s, System.StringComparer.Ordinal),
-                    Is.EqualTo(
-                        offResult.Select(WordResultSignature).OrderBy(s => s, System.StringComparer.Ordinal)
-                    ),
+                    Is.EqualTo(offResult.Select(WordResultSignature).OrderBy(s => s, System.StringComparer.Ordinal)),
                     $"lexical-gate-on parse of '{word}' must match gate-off parse"
                 );
             }

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/MorpherTests.cs
@@ -880,11 +880,44 @@ public class MorpherTests : HermitCrabTestBase
         Allophonic.PhonologicalRules.Add(epenthesis);
         try
         {
-            Assert.That(GrammarAnalyzer.ComputeMaxAnalysisLength(Language, 0), Is.Null);
+            Assert.That(GrammarAnalyzer.ComputeMaxAnalysisLength(Language), Is.Null);
         }
         finally
         {
             Allophonic.PhonologicalRules.Remove(epenthesis);
+        }
+    }
+
+    [Test]
+    public void ComputeMaxAnalysisLength_ReturnsNull_ForDeletionRewriteRule()
+    {
+        // LT-22613 follow-up: a deletion/coalescence-type rewrite subrule (Lhs longer than Rhs) is
+        // unapplied by the same NarrowAnalysisRewriteRuleSpec as expansion, which always inserts
+        // Lhs.Count new (Optional, not Deleted) nodes per match site and leaves the matched Rhs-shaped
+        // region in place (also not Deleted) -- so real per-site growth is Lhs.Count, not the
+        // Lhs.Count - Rhs.Count this method used to budget. That undercounts by Rhs.Count whenever
+        // Rhs.Count > 0, making the bound inadmissible here too, not just for insertion.
+        var vowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Value;
+        var coalescence = new RewriteRule
+        {
+            Name = "coalescence",
+            ApplicationMode = RewriteApplicationMode.Simultaneous,
+            Lhs = Pattern<Word, int>.New().Annotation(vowel).Annotation(vowel).Value,
+        };
+        coalescence.Subrules.Add(new RewriteSubrule { Rhs = Pattern<Word, int>.New().Annotation(vowel).Value });
+        Allophonic.PhonologicalRules.Add(coalescence);
+        try
+        {
+            Assert.That(GrammarAnalyzer.ComputeMaxAnalysisLength(Language), Is.Null);
+        }
+        finally
+        {
+            Allophonic.PhonologicalRules.Remove(coalescence);
         }
     }
 }

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/RewriteRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/RewriteRuleTests.cs
@@ -1342,6 +1342,111 @@ public class RewriteRuleTests : HermitCrabTestBase
     }
 
     [Test]
+    public void EpenthesisRuleWithMinimalLexicon()
+    {
+        // LT-22613 regression: the default (non-tracing) parse path must give the same answer as the
+        // traced path. EpenthesisRules above only passes because this fixture's large lexicon makes
+        // GrammarAnalyzer.ComputeMaxAnalysisLength's auto-derived bound big enough to hide the bug: an
+        // epenthesis rule's unapplication marks the inserted segments OPTIONAL (it never removes them,
+        // see EpenthesisAnalysisRewriteRuleSpec.Unapply), so a surface form that outgrew the longest
+        // root via epenthesis still counts all its segments at AnalysisStratumRule's length gate and
+        // was pruned as "unreachable" -- 0 parses non-traced, 1 parse traced. This grammar is
+        // EpenthesisRules sub-case (1) with the lexicon cut down to root 19 alone ("b+ubu", 4
+        // segments), so surface "buibui" (6 segments) exceeds any bound derived from the lexicon.
+        var highVowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Symbol("high+")
+            .Value;
+        var highFrontUnrndVowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Symbol("high+")
+            .Symbol("back-")
+            .Symbol("round-")
+            .Value;
+
+        var morphophonemic = new Stratum(Table3)
+        {
+            Name = "Morphophonemic",
+            MorphologicalRuleOrder = MorphologicalRuleOrder.Unordered,
+        };
+        var allophonic = new Stratum(Table1)
+        {
+            Name = "Allophonic",
+            MorphologicalRuleOrder = MorphologicalRuleOrder.Unordered,
+        };
+        var surface = new Stratum(Table1) { Name = "Surface", MorphologicalRuleOrder = MorphologicalRuleOrder.Unordered };
+
+        var entry = new LexEntry
+        {
+            Id = "19",
+            SyntacticFeatureStruct = FeatureStruct.New(Language.SyntacticFeatureSystem).Symbol("N").Value,
+            Gloss = "19",
+        };
+        entry.Allomorphs.Add(new RootAllomorph(new Segments(Table3, "b+ubu", true)));
+        morphophonemic.Entries.Add(entry);
+
+        var rule4 = new RewriteRule { Name = "rule4", ApplicationMode = RewriteApplicationMode.Simultaneous };
+        allophonic.PhonologicalRules.Add(rule4);
+        rule4.Subrules.Add(
+            new RewriteSubrule
+            {
+                Rhs = Pattern<Word, int>.New().Annotation(highFrontUnrndVowel).Value,
+                LeftEnvironment = Pattern<Word, int>.New().Annotation(highVowel).Value,
+            }
+        );
+
+        var lang = new Language
+        {
+            Name = "EpenthesisMinimal",
+            PhonologicalFeatureSystem = Language.PhonologicalFeatureSystem,
+            SyntacticFeatureSystem = Language.SyntacticFeatureSystem,
+            Strata = { morphophonemic, allophonic, surface },
+        };
+
+        var morpher = new Morpher(TraceManager, lang);
+        AssertMorphsEqual(morpher.ParseWord("buibui"), "19");
+
+        // The same over-prune is not Simultaneous-specific -- any insertion-type subrule's
+        // unapplication leaves the inserted segments in the shape as optional nodes. This is
+        // EpenthesisRules's Iterative cons_highBackRndVowel sub-case, same minimal lexicon.
+        var highBackRndVowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Symbol("high+")
+            .Symbol("back+")
+            .Symbol("round+")
+            .Value;
+        var cons = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons+")
+            .Symbol("voc-")
+            .Value;
+
+        rule4.ApplicationMode = RewriteApplicationMode.Iterative;
+        rule4.Subrules.Clear();
+        rule4.Subrules.Add(
+            new RewriteSubrule
+            {
+                Rhs = Pattern<Word, int>.New().Annotation(highFrontUnrndVowel).Value,
+                LeftEnvironment = Pattern<Word, int>.New().Annotation(cons).Value,
+                RightEnvironment = Pattern<Word, int>.New().Annotation(highBackRndVowel).Value,
+            }
+        );
+
+        morpher = new Morpher(TraceManager, lang);
+        AssertMorphsEqual(morpher.ParseWord("biubiu"), "19");
+    }
+
+    [Test]
     public void DeletionRules()
     {
         var highFrontUnrndVowel = FeatureStruct

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/RewriteRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/RewriteRuleTests.cs
@@ -1380,7 +1380,11 @@ public class RewriteRuleTests : HermitCrabTestBase
             Name = "Allophonic",
             MorphologicalRuleOrder = MorphologicalRuleOrder.Unordered,
         };
-        var surface = new Stratum(Table1) { Name = "Surface", MorphologicalRuleOrder = MorphologicalRuleOrder.Unordered };
+        var surface = new Stratum(Table1)
+        {
+            Name = "Surface",
+            MorphologicalRuleOrder = MorphologicalRuleOrder.Unordered,
+        };
 
         var entry = new LexEntry
         {


### PR DESCRIPTION
## Summary

Fixes LT-22613: `Morpher.ParseWord`'s default (non-tracing) path returned 0 parses for words a grammar should legitimately parse, while the traced path (which happens to skip this gate) correctly returned 1. The JIRA issue's original write-up hypothesized the cause was `AnalysisScope`'s nogood-memoization cache — that was investigated and **disproven** (toggling the memo cache independently of the real cause changes nothing); see the corrective comment added to LT-22613 and the corrected analysis doc on `bug/csharp-nogood-cache-tracing-divergence` (`rust/docs/bugs/csharp-nogood-cache-tracing-divergence.md`).

**Actual root cause:** `GrammarAnalyzer.ComputeMaxAnalysisLength` (Phase 4 "Gate B" of `parse-optimization.md`) computes a grammar-wide upper bound on analysis-form length, used by `AnalysisStratumRule.Apply` to prune candidates early — but only on the default, non-tracing path. For any phonological rewrite subrule where `Lhs.Count != Rhs.Count`, the analysis-side unapplication (`EpenthesisAnalysisRewriteRuleSpec`/`NarrowAnalysisRewriteRuleSpec`) never shrinks the candidate shape — it adds new `Optional` (not `Deleted`) nodes, which `Shape.SegmentCount()` still counts. The bound assumed growth of `Lhs.Count - Rhs.Count` per match site; real growth is always `Lhs.Count`, regardless of direction. This under-counted the true bound and pruned valid candidates as "too long."

- `9a43d251` fixes the insertion/expansion case (`Rhs.Count > Lhs.Count`, epenthesis when `Lhs` is empty).
- `93e52dc9` broadens the fix to any count mismatch after an independent adversarial review found the identical bug shape in deletion/coalescence subrules (`Lhs.Count > Rhs.Count`), and removes the now-unreachable deletion-reapplication compounding logic (and the `DeletionReapplications` parameter it consumed) as dead code.

Base is `parse-optimization` (not `master`): `GrammarAnalyzer`/`AnalysisScope`/`MaxAnalysisLength` only exist on this branch (PR #451, based on `hc-rustify` PR #446).

## Test plan

- [x] `dotnet build` — full solution, 0 warnings/errors
- [x] `dotnet test tests/SIL.Machine.Morphology.HermitCrab.Tests` — 71/71 passed
- [x] New regression tests, independently verified red-then-green against each parent commit:
  - `ComputeMaxAnalysisLength_ReturnsNull_ForInsertionRewriteRule` / `ForDeletionRewriteRule` (unit-level bound assertions)
  - `EpenthesisRuleWithMinimalLexicon` (end-to-end minimal-lexicon parse, default vs. traced path)
- [x] JIRA LT-22613 updated with the corrected root cause and these commit references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/453)
<!-- Reviewable:end -->
