### PR TITLE
Fix verses appearing in remarks when missing a paragraph marker

### DIFF
--- a/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
+++ b/src/SIL.Machine/Corpora/UpdateUsfmParserHandler.cs
@@ -490,6 +490,10 @@ namespace SIL.Machine.Corpora
                                     index++;
                             }
 
+                            // If the next token is a verse, add \nb to prevent the verse appearing in the remark
+                            if (tokens[index].Type == UsfmTokenType.Verse)
+                                tokens.Insert(index, new UsfmToken(UsfmTokenType.Paragraph, "nb", null, null));
+
                             tokens.InsertRange(index, remarkTokens.Value);
                         }
                     }

--- a/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
+++ b/tests/SIL.Machine.Tests/Corpora/UpdateUsfmParserHandlerTests.cs
@@ -1366,6 +1366,61 @@ public class UpdateUsfmParserHandlerTests
 \ide UTF-8
 \rem Existing remark
 \c 1
+\p
+\v 1 Some text
+\v 2
+\v 3 Other text
+\c 2
+\rem Existing remark
+\p
+\v 1 More text
+\c 3
+";
+
+        string target = UpdateUsfm(
+            rows,
+            usfm,
+            textBehavior: UpdateUsfmTextBehavior.PreferExisting,
+            remarks: [(0, "New remark 0"), (1, "New remark 1"), (2, "New remark 2"), (3, "New remark 3")]
+        );
+
+        string result =
+            @"\id MAT - Test
+\ide UTF-8
+\rem Existing remark
+\rem New remark 0
+\c 1
+\rem New remark 1
+\p
+\v 1 Some text
+\v 2 Update 2
+\v 3 Other text
+\c 2
+\rem Existing remark
+\rem New remark 2
+\p
+\v 1 More text
+\c 3
+\rem New remark 3
+";
+
+        AssertUsfmEquals(target, result);
+    }
+
+    [Test]
+    public void GetUsfm_PassRemark_NoBodyParagraph()
+    {
+        List<UpdateUsfmRow> rows =
+        [
+            new UpdateUsfmRow(ScrRef("MAT 1:1"), "Update 1"),
+            new UpdateUsfmRow(ScrRef("MAT 1:2"), "Update 2"),
+        ];
+
+        string usfm =
+            @"\id MAT - Test
+\ide UTF-8
+\rem Existing remark
+\c 1
 \v 1 Some text
 \v 2
 \v 3 Other text
@@ -1389,12 +1444,14 @@ public class UpdateUsfmParserHandlerTests
 \rem New remark 0
 \c 1
 \rem New remark 1
+\nb
 \v 1 Some text
 \v 2 Update 2
 \v 3 Other text
 \c 2
 \rem Existing remark
 \rem New remark 2
+\nb
 \v 1 More text
 \c 3
 \rem New remark 3
@@ -1455,6 +1512,7 @@ public class UpdateUsfmParserHandlerTests
 \ide UTF-8
 \rem Existing remark
 \c 1
+\q1
 \v 1 Some text
 \v 2
 \v 3 Other text
@@ -1476,6 +1534,7 @@ public class UpdateUsfmParserHandlerTests
 \c 1
 \rem New remark 1.1
 \rem New remark 1.2
+\q1
 \v 1 Some text
 \v 2 Update 2
 \v 3 Other text


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/1003

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/462)
<!-- Reviewable:end -->
