### PR TITLE
Fix unhandled InvalidCastException when a rewrite/metathesis rule has a top-level Quantifier

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRuleSpec.cs
@@ -50,7 +50,8 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
         {
             var newGroup = new Group<Word, ShapeNode>(name);
             foreach (
-                Constraint<Word, ShapeNode> constraint in groups[name].Children.Cast<Constraint<Word, ShapeNode>>()
+                Constraint<Word, ShapeNode> constraint in groups[name]
+                    .Children.CastToConstraints("A switch group of a metathesis rule")
             )
             {
                 Constraint<Word, ShapeNode> newConstraint = constraint.Clone();

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/EpenthesisAnalysisRewriteRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/EpenthesisAnalysisRewriteRuleSpec.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using SIL.Machine.Annotations;
 using SIL.Machine.FeatureModel;
 using SIL.Machine.Matching;
@@ -15,7 +14,11 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             Pattern.Acceptable = IsUnapplicationNonvacuous;
             _targetCount = subrule.Rhs.Children.Count;
 
-            foreach (Constraint<Word, ShapeNode> constraint in subrule.Rhs.Children.Cast<Constraint<Word, ShapeNode>>())
+            foreach (
+                Constraint<Word, ShapeNode> constraint in subrule.Rhs.Children.CastToConstraints(
+                    "The replacement (right-hand side) of an epenthesis rewrite subrule"
+                )
+            )
             {
                 Constraint<Word, ShapeNode> newConstraint = constraint.Clone();
                 newConstraint.FeatureStruct.AddValue(HCFeatureSystem.Modified, HCFeatureSystem.Clean);

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/FeatureAnalysisRewriteRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/FeatureAnalysisRewriteRuleSpec.cs
@@ -39,8 +39,12 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
                 )
             )
             {
-                var lhsConstraint = (Constraint<Word, ShapeNode>)tuple.Item1;
-                var rhsConstraint = (Constraint<Word, ShapeNode>)tuple.Item2;
+                Constraint<Word, ShapeNode> lhsConstraint = tuple.Item1.AsConstraint(
+                    "The target (left-hand side) of a rewrite rule"
+                );
+                Constraint<Word, ShapeNode> rhsConstraint = tuple.Item2.AsConstraint(
+                    "The replacement (right-hand side) of a rewrite subrule"
+                );
 
                 if (lhsConstraint.Type() == HCFeatureSystem.Segment && rhsConstraint.Type() == HCFeatureSystem.Segment)
                 {

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/NarrowAnalysisRewriteRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/NarrowAnalysisRewriteRuleSpec.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using SIL.Extensions;
 using SIL.Machine.Annotations;
 using SIL.Machine.FeatureModel;
@@ -42,7 +41,9 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
         {
             ShapeNode curNode = IsTargetEmpty ? range.Start : range.End;
             foreach (
-                Constraint<Word, ShapeNode> constraint in _analysisRhs.Children.Cast<Constraint<Word, ShapeNode>>()
+                Constraint<Word, ShapeNode> constraint in _analysisRhs.Children.CastToConstraints(
+                    "The target (left-hand side) of a rewrite rule"
+                )
             )
             {
                 FeatureStruct fs = constraint.FeatureStruct.Clone();

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/PatternNodeCastExtensions.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/PatternNodeCastExtensions.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using SIL.Machine.Annotations;
+using SIL.Machine.Matching;
+
+namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
+{
+    /// <summary>
+    /// Rewrite and metathesis rule specs assume that every top-level child of a rule's target/replacement
+    /// pattern (or a metathesis switch group) is a simple <see cref="Constraint{TData, TOffset}"/> (a
+    /// segment, natural class, or boundary marker). <see cref="Constraint{TData, TOffset}"/> and
+    /// <see cref="Quantifier{TData, TOffset}"/> are both direct subclasses of
+    /// <see cref="PatternNode{TData, TOffset}"/> -- siblings, not related by inheritance -- but the DTD and
+    /// <c>XmlLanguageLoader</c> allow an <c>OptionalSegmentSequence</c> (loaded as a <see cref="Quantifier{TData, TOffset}"/>)
+    /// in exactly the same positions as a plain segment. These helpers replace unchecked
+    /// <c>Cast&lt;Constraint&lt;Word, ShapeNode&gt;&gt;()</c> calls and direct casts with a checked
+    /// conversion that raises a clear, actionable <see cref="CompileException"/> naming the unsupported
+    /// construct and where it appeared, instead of an opaque <see cref="System.InvalidCastException"/>.
+    /// </summary>
+    internal static class PatternNodeCastExtensions
+    {
+        public static IEnumerable<Constraint<Word, ShapeNode>> CastToConstraints(
+            this IEnumerable<PatternNode<Word, ShapeNode>> nodes,
+            string context
+        )
+        {
+            foreach (PatternNode<Word, ShapeNode> node in nodes)
+                yield return node.AsConstraint(context);
+        }
+
+        public static Constraint<Word, ShapeNode> AsConstraint(this PatternNode<Word, ShapeNode> node, string context)
+        {
+            if (node is Constraint<Word, ShapeNode> constraint)
+                return constraint;
+
+            throw new CompileException(
+                $"{context} contains a '{node.GetType().Name}', which is not supported there. Only simple "
+                    + "segments, natural classes, and boundary markers are supported; optional or repeated "
+                    + "segment sequences (quantifiers) are only supported within a rule's left/right environment."
+            );
+        }
+    }
+}

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
@@ -28,7 +28,9 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
                 {
                     var newGroup = new Group<Word, ShapeNode>(group.Name);
                     foreach (
-                        Constraint<Word, ShapeNode> constraint in group.Children.Cast<Constraint<Word, ShapeNode>>()
+                        Constraint<Word, ShapeNode> constraint in group.Children.CastToConstraints(
+                            "A switch group of a metathesis rule"
+                        )
                     )
                     {
                         Constraint<Word, ShapeNode> newConstraint = constraint.Clone();

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisRewriteRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisRewriteRuleSpec.cs
@@ -30,7 +30,11 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             }
             else
             {
-                foreach (Constraint<Word, ShapeNode> constraint in lhs.Children.Cast<Constraint<Word, ShapeNode>>())
+                foreach (
+                    Constraint<Word, ShapeNode> constraint in lhs.Children.CastToConstraints(
+                        "The target (left-hand side) of a rewrite rule"
+                    )
+                )
                 {
                     var newConstraint = constraint.Clone();
                     if (isIterative)
@@ -90,7 +94,9 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
                     .Zip(lhs.Children)
             )
             {
-                var constraints = (Constraint<Word, ShapeNode>)tuple.Item2;
+                Constraint<Word, ShapeNode> constraints = tuple.Item2.AsConstraint(
+                    "The target (left-hand side) of a rewrite rule"
+                );
                 if (tuple.Item1.Annotation.Type() != constraints.Type())
                     return false;
             }

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/RewriteRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/RewriteRuleTests.cs
@@ -1923,4 +1923,89 @@ public class RewriteRuleTests : HermitCrabTestBase
         morpher = new Morpher(TraceManager, Language);
         AssertMorphsEqual(morpher.ParseWord("gigugi"), "44");
     }
+
+    // Constraint<TData, TOffset> and Quantifier<TData, TOffset> are both direct subclasses of
+    // PatternNode<TData, TOffset> (siblings, not related by inheritance). The DTD permits an
+    // OptionalSegmentSequence (loaded as a Quantifier) anywhere a plain Segment/SimpleContext is
+    // permitted in a PhoneticSequence, including as the target (Lhs) or replacement (Rhs) of a rewrite
+    // rule -- not just in its environments. Before the fix, the rule specs assumed every top-level
+    // Lhs/Rhs child was a Constraint and cast accordingly, so a DTD-legal Quantifier there crashed with
+    // an unhandled InvalidCastException deep inside Morpher construction. These tests build such rules
+    // directly (bypassing the XML loader, like the rest of this file) and confirm that constructing a
+    // Morpher over them now fails fast with a clear, typed CompileException instead.
+    [Test]
+    public void QuantifierInTargetIsRejectedWithClearError()
+    {
+        var highVowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Symbol("high+")
+            .Value;
+
+        var rule = new RewriteRule
+        {
+            Name = "quantifierInLhs",
+            // The Lhs is a single top-level Quantifier (an optional segment). The subrule has no Rhs
+            // (a deletion, 0 children), so the Lhs/Rhs child counts intentionally differ: this steers
+            // the analysis side to NarrowAnalysisRewriteRuleSpec, which does not cast its Lhs/Rhs
+            // children eagerly, isolating the crash to SynthesisRewriteRuleSpec, which always validates
+            // every Lhs child up front regardless of subrule shape.
+            Lhs = Pattern<Word, ShapeNode>.New().Annotation(highVowel).Optional.Value,
+        };
+        Allophonic.PhonologicalRules.Add(rule);
+        rule.Subrules.Add(new RewriteSubrule());
+
+        CompileException ex = Assert.Throws<CompileException>(() => new Morpher(TraceManager, Language));
+        Exception innermost = Innermost(ex);
+        Assert.That(innermost, Is.TypeOf<CompileException>());
+        Assert.That(innermost.Message, Does.Contain("Quantifier"));
+    }
+
+    [Test]
+    public void QuantifierInReplacementIsRejectedWithClearError()
+    {
+        var highVowel = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("cons-")
+            .Symbol("voc+")
+            .Symbol("high+")
+            .Value;
+        var backRnd = FeatureStruct
+            .New(Language.PhonologicalFeatureSystem)
+            .Symbol(HCFeatureSystem.Segment)
+            .Symbol("back+")
+            .Symbol("round+")
+            .Value;
+
+        var rule = new RewriteRule
+        {
+            Name = "quantifierInRhs",
+            Lhs = Pattern<Word, ShapeNode>.New().Annotation(highVowel).Value,
+        };
+        Allophonic.PhonologicalRules.Add(rule);
+        rule.Subrules.Add(
+            // Lhs and Rhs child counts match (1 == 1), so this exercises FeatureAnalysisRewriteRuleSpec,
+            // which casts both the Lhs and Rhs children eagerly.
+            new RewriteSubrule { Rhs = Pattern<Word, ShapeNode>.New().Annotation(backRnd).Optional.Value }
+        );
+
+        // Before the fix, this already surfaced as a CompileException at the top level (an unrelated,
+        // pre-existing catch-all in AnalysisStratumRule wraps *any* exception from compiling a
+        // phonological rule), but its InnerException was a raw, uninformative InvalidCastException. The
+        // fix replaces that with a clear, typed CompileException naming the unsupported construct.
+        CompileException ex = Assert.Throws<CompileException>(() => new Morpher(TraceManager, Language));
+        Exception innermost = Innermost(ex);
+        Assert.That(innermost, Is.TypeOf<CompileException>());
+        Assert.That(innermost.Message, Does.Contain("Quantifier"));
+    }
+
+    private static Exception Innermost(Exception ex)
+    {
+        while (ex.InnerException != null)
+            ex = ex.InnerException;
+        return ex;
+    }
 }


### PR DESCRIPTION
## The bug

`Constraint<TData, TOffset>` (`src/SIL.Machine/Matching/Constraint.cs:12-13`) and `Quantifier<TData, TOffset>` (`src/SIL.Machine/Matching/Quantifier.cs:13-14`) are **both direct subclasses** of `PatternNode<TData, TOffset>` — siblings, with no inheritance relationship between them.

The HermitCrab rule specs assume every top-level child of a rule's target (Lhs) or replacement (Rhs) pattern — or a metathesis switch group — is a `Constraint`, and cast accordingly with `Children.Cast<Constraint<Word, ShapeNode>>()` or a direct `(Constraint<Word, ShapeNode>)` cast:

- `PhonologicalRules/SynthesisRewriteRuleSpec.cs:33` (and `:93`, lazily, via `Pattern.Acceptable`)
- `PhonologicalRules/FeatureAnalysisRewriteRuleSpec.cs:42-43`
- `PhonologicalRules/NarrowAnalysisRewriteRuleSpec.cs:45` (lazily, in `Unapply`)
- `PhonologicalRules/EpenthesisAnalysisRewriteRuleSpec.cs:18`
- `PhonologicalRules/SynthesisMetathesisRuleSpec.cs:31`
- `PhonologicalRules/AnalysisMetathesisRuleSpec.cs:53`

But the DTD's `PhoneticSequence` element (`HermitCrabInput.dtd:515`) allows an `OptionalSegmentSequence` in exactly the same positions as a plain `Segment`/`SimpleContext` — and `OptionalSegmentSequence` itself (`HermitCrabInput.dtd:560`) carries an `id` attribute explicitly documented as "only needed for a metathesis rule", so it's legal there too. `XmlLanguageLoader.LoadPatternNodes` (~1405-1415, ~1493-1505) builds a real `Quantifier` for an `OptionalSegmentSequence` with no LHS-vs-environment distinction.

So a **DTD-legal grammar** — a rewrite rule whose target or replacement contains a top-level optional/repeated segment sequence — crashes with an unhandled `InvalidCastException` during `Morpher` construction. Depending on which of the sites above runs first, it either propagates raw straight out of `new Morpher(...)` (the synthesis side has no try/catch around rule compilation), or gets caught by a pre-existing, unrelated catch-all in `AnalysisStratumRule.CompilePhonologicalRule` — but even then the message is uninformative (just names the rule; the real cause is buried in an opaque `InnerException`).

Quantifiers already work correctly in a rule's *environment* (`LeftEnvironment`/`RightEnvironment` — see the existing `QuantifierRules` test) since environment matching doesn't go through this cast. The bug is specific to the target/replacement/switch-group position.

## Reproduction

Verified directly (not hypothetical) — found while building an independent FST-based morphological analyzer/proposer ([PanGloss](https://github.com/sillsdev)) against this library; a grammar under construction hit this.

Two new tests in `RewriteRuleTests.cs` build a `RewriteRule` directly (bypassing the XML loader, matching the rest of that file) with a top-level `Quantifier` in the Lhs and, separately, the Rhs, then construct a `Morpher`:

- `QuantifierInTargetIsRejectedWithClearError` — before the fix, throws a **raw, unhandled `InvalidCastException`** straight out of `new Morpher(...)` (confirmed against unmodified `master`).
- `QuantifierInReplacementIsRejectedWithClearError` — before the fix, throws a `CompileException` (via the pre-existing `AnalysisStratumRule` wrapper) whose `InnerException` is the same raw, uninformative `InvalidCastException` (also confirmed against unmodified `master`).

## The fix

I considered two approaches:

1. **Genuinely support a `Quantifier` in this position** — the DTD permits it, so the library arguably should handle it.
2. **Convert the crash into a clear, typed, load-time diagnostic** naming the unsupported construct and where it appeared.

I went with **(2)**. Actually supporting a variable-width quantifier as the *target* of a rewrite rule (matched-and-replaced, or matched-and-deleted) is a real semantic feature, not a mechanical fix — it changes what "the same number of Lhs and Rhs children" even means for the whole rewrite-subrule-shape dispatch (`Feature`/`Narrow`/`Epenthesis` selection) these classes are built around. That's too large and semantically risky a change to make confidently in an external repo I don't own, especially with no existing test/grammar exercising it to pin the intended behavior. A clear, fail-fast diagnostic is the conservative, reviewable option, and is a strict improvement over an opaque crash either way.

Added `PatternNodeCastExtensions` (`CastToConstraints` / `AsConstraint`) and used it at every site above instead of the unchecked cast. For any grammar built entirely from `Constraint`s — i.e. **every currently-working grammar** — behavior is byte-for-byte unchanged: the helper returns the exact same `Constraint` the cast would have produced. When a `Quantifier` (or any other non-`Constraint` `PatternNode`) shows up in one of these positions, it now raises a `CompileException` such as:

> The target (left-hand side) of a rewrite rule contains a 'Quantifier\`2', which is not supported there. Only simple segments, natural classes, and boundary markers are supported; optional or repeated segment sequences (quantifiers) are only supported within a rule's left/right environment.

## Test evidence

Full solution, before vs. after (temporarily reverted just the 6 fixed `src/` files to `master`'s content to confirm red state, then restored):

**Before the fix** (unmodified `master` + the two new tests): both new tests fail —
- `QuantifierInTargetIsRejectedWithClearError`: raw `System.InvalidCastException` thrown directly from `new Morpher(...)`, at `SynthesisRewriteRuleSpec.cs:33`.
- `QuantifierInReplacementIsRejectedWithClearError`: `CompileException` wrapping a raw `InvalidCastException` at `FeatureAnalysisRewriteRuleSpec.cs:43`.

**After the fix**: full solution build clean (0 errors, 0 new warnings), `dotnet test` on the whole solution:

```
SIL.Machine.Tokenization.SentencePiece.Tests: Passed: 4, Failed: 0
SIL.Machine.Morphology.HermitCrab.Tests:      Passed: 68, Failed: 0   (66 pre-existing + 2 new)
SIL.Machine.Translation.Thot.Tests:           Passed: 83, Failed: 0
SIL.Machine.Tests:                            Passed: 804, Failed: 0, Skipped: 3 (pre-existing, unrelated)
```

All pre-existing tests pass unchanged; only the two new tests are added.

Ran `dotnet csharpier format` on the touched files only (no wholesale reformatting).

## Test plan

- [x] Reproducing tests added, confirmed failing against unmodified `master`
- [x] Fix applied, same tests now pass
- [x] Full solution `dotnet build`: clean
- [x] Full solution `dotnet test`: all pass (962 total, 3 pre-existing unrelated skips)
- [x] `dotnet csharpier check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/464)
<!-- Reviewable:end -->
