### PR TITLE
Add 4 construct rows for characteristics with no coverage id

### DIFF
--- a/conformance/constructs.txt
+++ b/conformance/constructs.txt
@@ -26,10 +26,14 @@ MorphologicalOutputAction: CopyFromInput/InsertSegments
 MorphologicalOutputAction: ModifyFromInput/InsertSimpleContext
 RewriteRule Iterative (epenthesis/deletion/feature/expansion/merge)
 RewriteRule Simultaneous
+RewriteRule direction (Dir): left-to-right
+RewriteRule direction (Dir): right-to-left
+RewriteSubruleDef gating: required/excluded POS or MPR at the subrule level
 MetathesisRule
 Affix template slots (obligatory/disjunctive/ordering)
 NaturalClass: Segments vs FeatureNaturalClass/SegmentNaturalClass precision
 Boundary markers (CharacterDefinitionTable)
+CharacterDefinitionTable: more than one table, one per stratum
 MorphemeCoOccurrenceRule/AllomorphCoOccurrenceRule
 MPR features/groups
 Guesser/LexicalGuess


### PR DESCRIPTION
## Summary
- PanGloss's `pg-foma::conformance_coverage` cross-check maps every `CharacteristicKind` to one or more `constructs.txt` identifiers. Four characteristics had no corresponding row at all, so no fixture could ever be written to exercise them by name: rewrite-rule directionality (left-to-right / right-to-left), phonological subrule-level MPR/POS gating, and stratification across more than one `CharacterDefinitionTable`.
- Adds one new row per characteristic, next to the closest existing related rows, in the file's existing plain-line style. No renumbering or reordering of existing rows.

## Detail
- `RewriteRule direction (Dir): left-to-right` / `RewriteRule direction (Dir): right-to-left` — the existing `RewriteRule Iterative`/`RewriteRule Simultaneous` rows tag *application order*, not *directionality*; no row named direction as its own phenomenon.
- `RewriteSubruleDef gating: required/excluded POS or MPR at the subrule level` — the existing `MPR features/groups` row is morphological `MprGroup` territory (`MprGroupAppend`/`MprGroupOverwrite`); this is the distinct phonological-subrule gate.
- `CharacterDefinitionTable: more than one table, one per stratum` — the two existing `CharacterDefinitionTable` rows are about segmentation/pattern constructs *within* one table, not about multiple tables potentially disagreeing across strata.

## Test plan
- [x] Format matches the file's existing convention (one construct per line, no header changes)
- [ ] CI (if any) on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/465)
<!-- Reviewable:end -->
