### PR TITLE
fix(hermitcrab): make metathesis switch-name order not matter

### DIFF
--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRuleSpec.cs
@@ -31,12 +31,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
                 _pattern.Children.Add(node.Clone());
             }
 
-            // The analysis pattern has to match the SURFACE, where the two switch groups appear in the
-            // opposite order from the pattern that describes the underlying form. So the group that is
-            // later in the pattern is emitted first. Rules that name the later group as the left switch
-            // already satisfy that; ordering by pattern position instead of by name makes a rule behave
-            // the same whichever way round its switch names are written, and keeps this spec consistent
-            // with the synthesis spec's own normalization.
+            // This pattern matches the surface, where the switch groups appear in reverse pattern order.
             int leftIndex = Array.FindIndex(groupOrder, g => g.Name == leftGroupName);
             int rightIndex = Array.FindIndex(groupOrder, g => g.Name == rightGroupName);
             string firstName = leftIndex < rightIndex ? rightGroupName : leftGroupName;

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/AnalysisMetathesisRuleSpec.cs
@@ -31,8 +31,18 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
                 _pattern.Children.Add(node.Clone());
             }
 
-            AddGroup(groups, leftGroupName);
-            AddGroup(groups, rightGroupName);
+            // The analysis pattern has to match the SURFACE, where the two switch groups appear in the
+            // opposite order from the pattern that describes the underlying form. So the group that is
+            // later in the pattern is emitted first. Rules that name the later group as the left switch
+            // already satisfy that; ordering by pattern position instead of by name makes a rule behave
+            // the same whichever way round its switch names are written, and keeps this spec consistent
+            // with the synthesis spec's own normalization.
+            int leftIndex = Array.FindIndex(groupOrder, g => g.Name == leftGroupName);
+            int rightIndex = Array.FindIndex(groupOrder, g => g.Name == rightGroupName);
+            string firstName = leftIndex < rightIndex ? rightGroupName : leftGroupName;
+            string secondName = leftIndex < rightIndex ? leftGroupName : rightGroupName;
+            AddGroup(groups, firstName);
+            AddGroup(groups, secondName);
 
             foreach (
                 PatternNode<Word, ShapeNode> node in pattern

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
@@ -100,11 +100,8 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             GroupCapture<ShapeNode> leftGroup = targetMatch.GroupCaptures[_leftGroupName];
             GroupCapture<ShapeNode> rightGroup = targetMatch.GroupCaptures[_rightGroupName];
 
-            // The splice below only works when the first group it is handed is the LATER of the two in
-            // shape order: it moves that group's nodes out to the right, then moves the other group
-            // into the gap. Handed them the other way round, the second move re-anchors a group after
-            // its own end, which detaches nodes and leaves annotation ranges spanning two lists.
-            // Nothing in the switch names implies an order, so normalize instead of assuming one.
+            // The splice below needs the later group in shape order first; reversed, its second move
+            // re-anchors a group after its own end.
             if (leftGroup.Range.Start.CompareTo(rightGroup.Range.Start) < 0)
             {
                 GroupCapture<ShapeNode> earlier = leftGroup;

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
@@ -101,8 +101,8 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             GroupCapture<ShapeNode> rightGroup = targetMatch.GroupCaptures[_rightGroupName];
 
             // The splice below needs the later group in shape order first; reversed, its second move
-            // re-anchors a group after its own end.
-            if (leftGroup.Range.Start.CompareTo(rightGroup.Range.Start) < 0)
+            // re-anchors a group after its own end. An unmatched capture has no start to compare.
+            if (leftGroup.Success && rightGroup.Success && leftGroup.Range.Start.CompareTo(rightGroup.Range.Start) < 0)
             {
                 GroupCapture<ShapeNode> earlier = leftGroup;
                 leftGroup = rightGroup;

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
@@ -100,8 +100,7 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             GroupCapture<ShapeNode> leftGroup = targetMatch.GroupCaptures[_leftGroupName];
             GroupCapture<ShapeNode> rightGroup = targetMatch.GroupCaptures[_rightGroupName];
 
-            // The splice below needs the later group in shape order first; reversed, its second move
-            // re-anchors a group after its own end. An unmatched capture has no start to compare.
+            // The splice below needs the later shape-order group first, or its second move re-anchors past its own end.
             if (leftGroup.Success && rightGroup.Success && leftGroup.Range.Start.CompareTo(rightGroup.Range.Start) < 0)
             {
                 GroupCapture<ShapeNode> earlier = leftGroup;

--- a/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/PhonologicalRules/SynthesisMetathesisRuleSpec.cs
@@ -100,6 +100,18 @@ namespace SIL.Machine.Morphology.HermitCrab.PhonologicalRules
             GroupCapture<ShapeNode> leftGroup = targetMatch.GroupCaptures[_leftGroupName];
             GroupCapture<ShapeNode> rightGroup = targetMatch.GroupCaptures[_rightGroupName];
 
+            // The splice below only works when the first group it is handed is the LATER of the two in
+            // shape order: it moves that group's nodes out to the right, then moves the other group
+            // into the gap. Handed them the other way round, the second move re-anchors a group after
+            // its own end, which detaches nodes and leaves annotation ranges spanning two lists.
+            // Nothing in the switch names implies an order, so normalize instead of assuming one.
+            if (leftGroup.Range.Start.CompareTo(rightGroup.Range.Start) < 0)
+            {
+                GroupCapture<ShapeNode> earlier = leftGroup;
+                leftGroup = rightGroup;
+                rightGroup = earlier;
+            }
+
             ShapeNode beforeRightGroup = rightGroup.Range.Start.Prev;
             MoveNodesAfter(targetMatch.Input.Shape, leftGroup.Range.End, rightGroup.Range);
             MoveNodesAfter(targetMatch.Input.Shape, beforeRightGroup, leftGroup.Range);

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/MetathesisRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/MetathesisRuleTests.cs
@@ -28,11 +28,7 @@ public class MetathesisRuleTests : HermitCrabTestBase
         AssertMorphsEqual(morpher.ParseWord("mui"), "51");
     }
 
-    // Regression: naming the EARLIER group as the left switch threw InvalidOperationException "Failed
-    // to compare two elements in the array", wrapping "Only nodes from the same list can be compared",
-    // instead of producing an analysis. Every pre-existing test here names the later group first, which
-    // is why the intuitive order was never exercised. Direction is irrelevant; this reproduces under
-    // both.
+    // Differs from SimpleRule only in the switch-name order, and must give the same result.
     [Test]
     public void SimpleRule_LeftSwitchNamesEarlierGroup()
     {

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/MetathesisRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/MetathesisRuleTests.cs
@@ -28,6 +28,31 @@ public class MetathesisRuleTests : HermitCrabTestBase
         AssertMorphsEqual(morpher.ParseWord("mui"), "51");
     }
 
+    // Regression: naming the EARLIER group as the left switch threw InvalidOperationException "Failed
+    // to compare two elements in the array", wrapping "Only nodes from the same list can be compared",
+    // instead of producing an analysis. Every pre-existing test here names the later group first, which
+    // is why the intuitive order was never exercised. Direction is irrelevant; this reproduces under
+    // both.
+    [Test]
+    public void SimpleRule_LeftSwitchNamesEarlierGroup()
+    {
+        var rule1 = new MetathesisRule
+        {
+            Name = "rule1",
+            Pattern = Pattern<Word, ShapeNode>
+                .New()
+                .Group("1", group => group.Annotation(Character(Table3, "i")))
+                .Group("2", group => group.Annotation(Character(Table3, "u")))
+                .Value,
+            LeftSwitchName = "1",
+            RightSwitchName = "2",
+        };
+        Morphophonemic.PhonologicalRules.Add(rule1);
+
+        var morpher = new Morpher(TraceManager, Language);
+        AssertMorphsEqual(morpher.ParseWord("mui"), "51");
+    }
+
     [Test]
     public void ComplexRule()
     {

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/MetathesisRuleTests.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/PhonologicalRules/MetathesisRuleTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using SIL.Machine.Annotations;
+using SIL.Machine.DataStructures;
 using SIL.Machine.FeatureModel;
 using SIL.Machine.Matching;
 using SIL.Machine.Morphology.HermitCrab.MorphologicalRules;
@@ -49,6 +50,28 @@ public class MetathesisRuleTests : HermitCrabTestBase
         AssertMorphsEqual(morpher.ParseWord("mui"), "51");
     }
 
+    // Differs from SimpleRule only in the switch-name order, plus a right-to-left direction.
+    [Test]
+    public void SimpleRule_LeftSwitchNamesEarlierGroup_RightToLeft()
+    {
+        var rule1 = new MetathesisRule
+        {
+            Name = "rule1",
+            Direction = Direction.RightToLeft,
+            Pattern = Pattern<Word, ShapeNode>
+                .New()
+                .Group("1", group => group.Annotation(Character(Table3, "i")))
+                .Group("2", group => group.Annotation(Character(Table3, "u")))
+                .Value,
+            LeftSwitchName = "1",
+            RightSwitchName = "2",
+        };
+        Morphophonemic.PhonologicalRules.Add(rule1);
+
+        var morpher = new Morpher(TraceManager, Language);
+        AssertMorphsEqual(morpher.ParseWord("mui"), "51");
+    }
+
     [Test]
     public void ComplexRule()
     {
@@ -66,6 +89,41 @@ public class MetathesisRuleTests : HermitCrabTestBase
                 .Value,
             LeftSwitchName = "2",
             RightSwitchName = "1",
+        };
+        Morphophonemic.PhonologicalRules.Add(rule1);
+
+        var uSuffix = new AffixProcessRule { Name = "u_suffix", Gloss = "3SG" };
+        Morphophonemic.MorphologicalRules.Add(uSuffix);
+        uSuffix.Allomorphs.Add(
+            new AffixProcessAllomorph
+            {
+                Lhs = { Pattern<Word, ShapeNode>.New("1").Annotation(any).OneOrMore.Value },
+                Rhs = { new CopyFromInput("1"), new InsertSegments(Table3, "+u") },
+            }
+        );
+
+        var morpher = new Morpher(TraceManager, Language);
+        AssertMorphsEqual(morpher.ParseWord("mui"), "53 3SG");
+    }
+
+    // ComplexRule with the switch names reversed: a group sits between the two switches.
+    [Test]
+    public void ComplexRule_LeftSwitchNamesEarlierGroup()
+    {
+        var any = FeatureStruct.New().Symbol(HCFeatureSystem.Segment).Value;
+
+        var rule1 = new MetathesisRule
+        {
+            Name = "rule1",
+            Pattern = Pattern<Word, ShapeNode>
+                .New()
+                .Group("1", group => group.Annotation(Character(Table3, "i")))
+                .Group("middle", group => group.Annotation(Character(Table3, "+")))
+                .Group("2", group => group.Annotation(Character(Table3, "u")))
+                .Group("rightEnv", group => group.Annotation(HCFeatureSystem.RightSideAnchor))
+                .Value,
+            LeftSwitchName = "1",
+            RightSwitchName = "2",
         };
         Morphophonemic.PhonologicalRules.Add(rule1);
 


### PR DESCRIPTION
## Problem

A `MetathesisRule` whose `leftSwitch` names the **earlier** of its two pattern groups throws instead of producing an analysis:

```
System.InvalidOperationException: Failed to compare two elements in the array.
 ---> System.ArgumentException: Only nodes from the same list can be compared. (Parameter 'other')
   at SIL.Machine.Annotations.ShapeNode.CompareTo(ShapeNode other)
   at SIL.Machine.Annotations.ShapeRangeFactory.Compare(ShapeNode x, ShapeNode y)
   at SIL.Machine.Annotations.Range`1.CompareTo(Range`1 other)
   at System.Linq.Enumerable.EnumerableSorter`2...
   at SIL.Machine.Morphology.HermitCrab.Morpher.Synthesize(...)
```

Both metathesis specs silently required the opposite orientation. Every pre-existing test in `MetathesisRuleTests` names the *later* group as the left switch, so the intuitive order was never exercised.

`Direction` is **not** involved — this reproduces under both `LeftToRight` and `RightToLeft`.

## Cause

`MoveNodesAfter` advances its `cur` anchor after every iterated node, whether or not that node was physically moved. In the failing orientation `beforeRightGroup` ends up equal to `leftGroup.Range.End`, so for a single-node group that node is simultaneously the move's anchor and the node being removed in the same iteration. `node.Remove()` sets its `List` to null and the following `cur.AddAfter(node)` never restores it. The orphaned node then reaches `morph.Children.OrderBy(ann => ann.Range)`, and `ShapeNode.CompareTo` throws because the two nodes belong to different lists.

Separately, `AnalysisMetathesisRuleSpec` builds its pattern in `leftSwitch`-then-`rightSwitch` order, but that pattern must match the **surface**, where the two groups appear in the opposite order from the underlying form. With the switch names reversed the analysis pattern matched nothing — so even with the crash fixed there was still no analysis.

## Fix

Both specs order the two switch groups by **pattern position** rather than by name, so a rule behaves identically whichever way its switch names are written.

For rules that already name the later group first the normalization is a **no-op**: the swap condition is false, and `AnalysisMetathesisRuleSpec` emits the same order it always did.

## Verification

Full `SIL.Machine.Morphology.HermitCrab.Tests` suite: **71/71 pass**. `dotnet csharpier check` clean.

Each half of the fix was reverted independently to confirm both are load-bearing:

| Reverted | Result |
|---|---|
| synthesis normalization | `SimpleRule_LeftSwitchNamesEarlierGroup` and its right-to-left variant reproduce the reported crash |
| analysis normalization | all three new tests fail with an empty analysis instead |
| neither | 71/71 pass |

Tests added:

- `SimpleRule_LeftSwitchNamesEarlierGroup` — differs from `SimpleRule` only in the switch-name order, and must give the same result
- `SimpleRule_LeftSwitchNamesEarlierGroup_RightToLeft` — same, with `Direction.RightToLeft`
- `ComplexRule_LeftSwitchNamesEarlierGroup` — reversed naming with a group between the two switches. Note this one passes even without the synthesis change; it guards the analysis-side ordering and the middle-group case rather than reproducing the crash.

## Scope, and what this does not close

This fixes the switch-name-order crash class. Two pre-existing hazards in the same code are left untouched and are not claimed to be fixed:

- `MoveNodesAfter` still advances `cur` past a skipped non-`Segment` node, so a switch group whose own range spans a boundary or anchor node could still anchor subsequent moves off a stale position. No current rule shape hits this.
- An unmatched switch capture has a null `Range.Start`. `beforeRightGroup`'s `.Prev` already dereferenced it before this change; the new comparison is guarded with `GroupCapture.Success` so it does not add a second such site, but the underlying assumption that both switches always match is unchanged.

## How it was found

While building generated-coverage fixtures for the HermitCrab XML surface on the `conformance-framework` branch: a fixture written to exercise `MetathesisRule@multipleApplicationOrder` wrote its switch names in the natural order and hit this. The ordering attribute turned out to be irrelevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/471)
<!-- Reviewable:end -->
