### PR TITLE
Update library to version 3.9.3

### DIFF
--- a/src/AssemblyInfo.props
+++ b/src/AssemblyInfo.props
@@ -1,9 +1,9 @@
 <Project>
 	<PropertyGroup>
-		<Version>3.9.2</Version>
+		<Version>3.9.3</Version>
 		<Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
-		<AssemblyVersion>3.9.2.0</AssemblyVersion>
-		<FileVersion>3.9.2.0</FileVersion>
+		<AssemblyVersion>3.9.3.0</AssemblyVersion>
+		<FileVersion>3.9.3.0</FileVersion>
 		<Company>SIL Global</Company>
 		<Authors>SIL Global</Authors>
 		<Product>Machine</Product>


### PR DESCRIPTION
This is needed in order for Serval to utilize the new shared low-confidence discriminator. It'd be great if we could get this in today so that we can do a QA release with all the DQE-related updates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/484)
<!-- Reviewable:end -->
