### PR TITLE
Fold-step synthesis memo: built, correct, and does not pay (evidence, not for merge)

### DIFF
--- a/docs/hermitcrab-synthesis-fold-probes.md
+++ b/docs/hermitcrab-synthesis-fold-probes.md
@@ -626,3 +626,52 @@ Commit `1a7d484c` bundles the harness reporting change with the section 8 analys
 agent that wrote the reporting change stopped with it uncommitted and the work was swept in when
 the analysis was committed. Two concerns in one commit; flagged here rather than rewritten, since
 the PR body is the review artifact.
+---
+
+## 10. The build was made, and it does not pay — because the redundancy is not real
+
+`feature/synthesis-fold-sharing` (`1048c742`) implements the fold-step memo with a sound key:
+`SynthesisStateKey` carries the **ordered remaining trail**, not just its index, plus shape,
+syntactic FS, realizational FS, MPR set, root allomorph, disjunctive allomorph indices, applied
+counts, `IsPartial`, `IsLastAppliedRuleFinal` and stratum — each field justified against its reader.
+
+**Parity: 0 divergences across all 33 conformance fixtures.** The implementation is correct.
+
+**Measured (warm-up discarded, min of 5 interleaved samples per arm):**
+
+| fixture | predicted ceiling | realised | memo hits | off-arm spread |
+| --- | --- | --- | --- | --- |
+| deep-optional-affix-nesting | 50.4% (~2x) | **0.96x** (4.5% slower) | **0** | 38.6% |
+| suffixing-evidential-adjacency-chain | 52.0% (~2x) | 1.06x (5.4%) | 2,682 | 21.9% |
+
+**`hits = 0` on the fixture with the largest reliable sample and the highest predicted ceiling.**
+With a trail-complete key the memo never fires there at all; the 0.96x is pure key-construction
+overhead. On the evidential chain it does fire 2,682 times and returns 5.4% against 21.9% noise —
+nothing.
+
+### The structural finding
+
+This is the same result arriving a third time, by a third independent route:
+
+| measurement | key | apparent | sound |
+| --- | --- | --- | --- |
+| F1 synthesis-input dedupe | order-insensitive | 9,774x | 15–40% |
+| N1 fold-entry census | trail position only | 6,476x | not established |
+| **P1c fold-step sharing** | **trail position only** | **3.22x / 8.10x** | **hits=0 / 1.06x** |
+
+**The redundancy in HermitCrab's synthesis is apparent, not real. The trail is what makes each
+step distinct, and every measurement that shows large shareable work is measuring a key that omits
+it.** Three different boundaries, three spectacular ratios, three collapses under a complete key.
+
+That closes a family, not just a candidate: packed parse forests, fold-step sharing, and
+synthesis-input dedupe all depend on distinct derivations converging on a genuinely identical
+state, and in this engine they do not converge. It is the same fact that makes the rules
+non-order-invariant, seen from the other side.
+
+### Recommendation
+
+**Do not merge the fold-step memo as a performance feature.** It is correct, it is off by default,
+and it buys nothing — on the best case it is 4% slower. Keep the branch as the evidence that
+closes the family.
+
+The measurement infrastructure is the durable asset and should merge on its own.

--- a/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Morpher.cs
@@ -30,6 +30,7 @@ namespace SIL.Machine.Morphology.HermitCrab
         private long _nogoodHits;
         private long _templateMemoHits;
         private long _templateNogoodHits;
+        private long _synthesisFoldHits;
 
         public Morpher(ITraceManager traceManager, Language lang, int maxDegreeOfParallelism = 0)
         {
@@ -90,6 +91,19 @@ namespace SIL.Machine.Morphology.HermitCrab
         public bool MergeEquivalentAnalyses { get; set; }
 
         /// <summary>
+        /// Turns on the synthesis fold-step memo (docs/hermitcrab-synthesis-fold-probes.md), which shares
+        /// <see cref="MorphologicalRules.SynthesisAffixProcessRule"/>/
+        /// <see cref="MorphologicalRules.SynthesisRealizationalAffixProcessRule"/> applications across
+        /// candidates that reach an equal <see cref="SynthesisStateKey"/>. Defaults to <c>false</c>: this is
+        /// a plain A/B toggle so both configurations can be measured in one process, not a change to any
+        /// default behaviour. Only takes effect in <c>Morpher.SynthesizeSequential</c>
+        /// (<see cref="MaxDegreeOfParallelism"/> == 1, untraced) -- same restriction as the analysis-cascade
+        /// memo, and for the same reason: <see cref="SynthesisFoldScope"/>'s table is a plain
+        /// <see cref="Dictionary{TKey,TValue}"/>, not thread-safe.
+        /// </summary>
+        public bool UseSynthesisFoldMemo { get; set; }
+
+        /// <summary>
         /// Caps the concurrency used within a single parse or generation -- analysis cascade,
         /// affix-template unapplication and synthesis alike. A value of 1 runs the work fully
         /// sequentially, and is the only configuration eligible for the analysis-cascade memo (see
@@ -125,6 +139,13 @@ namespace SIL.Machine.Morphology.HermitCrab
         internal long NogoodHits => Interlocked.Read(ref _nogoodHits);
         internal long TemplateMemoHits => Interlocked.Read(ref _templateMemoHits);
         internal long TemplateNogoodHits => Interlocked.Read(ref _templateNogoodHits);
+        internal long SynthesisFoldHits => Interlocked.Read(ref _synthesisFoldHits);
+
+        // Interlocked because one Morpher may be parsing on several threads at once.
+        private void AccumulateSynthesisFoldDiagnostics(SynthesisFoldScope scope)
+        {
+            Interlocked.Add(ref _synthesisFoldHits, scope.Hits);
+        }
 
         // Interlocked because one Morpher may be parsing on several threads at once.
         private void AccumulateMemoDiagnostics(AnalysisScope scope)
@@ -366,6 +387,13 @@ namespace SIL.Machine.Morphology.HermitCrab
         private IEnumerable<Word> SynthesizeSequential(string word, IEnumerable<Word> analyses)
         {
             var matches = new HashSet<Word>(FreezableEqualityComparer<Word>.Default);
+            // One scope for the whole surface-word parse, shared across every analysis word's alternatives
+            // -- exactly the scope P1c/N1 measured sharing over (docs/hermitcrab-synthesis-fold-probes.md).
+            // Never while tracing, matching AnalysisScope's own restriction: traces must stay byte-identical
+            // to the unmemoized engine. This method is only ever reached when MaxDegreeOfParallelism == 1
+            // (see Synthesize), so no separate parallelism check is needed here.
+            SynthesisFoldScope foldScope =
+                UseSynthesisFoldMemo && !_traceManager.IsTracing ? new SynthesisFoldScope() : null;
             int alternativeCount = 0;
             foreach (Word analysisWord in analyses)
             {
@@ -413,6 +441,9 @@ namespace SIL.Machine.Morphology.HermitCrab
                         if (MaxAlternatives > 0 && alternativeCount > MaxAlternatives)
                             throw new MaxAlternativesExceededException("MaxAlternatives exceeded");
 
+                        if (foldScope != null)
+                            alternative.SynthesisFoldScope = foldScope;
+
                         if (!SynthesisProbe.Enabled)
                         {
                             foreach (Word validWord in _synthesisRule.Apply(alternative).Where(IsWordValid))
@@ -447,6 +478,8 @@ namespace SIL.Machine.Morphology.HermitCrab
                     }
                 }
             }
+            if (foldScope != null)
+                AccumulateSynthesisFoldDiagnostics(foldScope);
             return matches;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisAffixProcessRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisAffixProcessRule.cs
@@ -40,12 +40,40 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
 
         public IEnumerable<Word> Apply(Word input)
         {
+            // The trail-position gate stays outside the memo unconditionally, on both the memoized and
+            // unmemoized paths: it is an O(1) index-plus-reference check (docs/hermitcrab-synthesis-fold-probes.md
+            // section 3's "~40x free" observation), so a SynthesisStateKey is never worth constructing for
+            // the ~72-73% of rejections that die here (section 6.1's P1b histogram).
             if (!input.IsMorphologicalRuleApplicable(_rule))
             {
                 SynthesisProbe.RecordDie(SynthesisDiePoint.RuleNotApplicableOrPatternMismatch);
                 return Enumerable.Empty<Word>();
             }
 
+            SynthesisFoldScope foldScope = _morpher.UseSynthesisFoldMemo ? input.SynthesisFoldScope : null;
+            if (foldScope == null)
+                return ApplyMatchingAllomorphs(input);
+
+            SynthesisStateKey key = SynthesisStateKey.PinAndKey(input);
+            if (foldScope.TryGet(key, _rule, out IReadOnlyList<Word> stored))
+            {
+                foldScope.Hits++;
+                var replayed = new List<Word>(stored.Count);
+                foreach (Word storedOutput in stored)
+                    replayed.Add(storedOutput.ReanchorSynthesisStep(input, trailConsuming: true));
+                return replayed;
+            }
+
+            var computed = ApplyMatchingAllomorphs(input).ToList();
+            foldScope.Store(key, _rule, computed);
+            return computed;
+        }
+
+        // Everything past the trail-position gate: this is the expensive part of the step (per-allomorph
+        // MPR checks, pattern matching, unification), and everything it reads is covered by
+        // SynthesisStateKey -- see that class's doc comment for the field-by-field audit.
+        private IEnumerable<Word> ApplyMatchingAllomorphs(Word input)
+        {
             if (input.GetApplicationCount(_rule) >= _rule.MaxApplicationCount)
             {
                 if (_morpher.TraceManager.IsTracing)

--- a/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisRealizationalAffixProcessRule.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/MorphologicalRules/SynthesisRealizationalAffixProcessRule.cs
@@ -43,6 +43,31 @@ namespace SIL.Machine.Morphology.HermitCrab.MorphologicalRules
             if (!_morpher.RuleSelector(_rule))
                 return Enumerable.Empty<Word>();
 
+            SynthesisFoldScope foldScope = _morpher.UseSynthesisFoldMemo ? input.SynthesisFoldScope : null;
+            if (foldScope == null)
+                return ApplyUncached(input);
+
+            SynthesisStateKey key = SynthesisStateKey.PinAndKey(input);
+            if (foldScope.TryGet(key, _rule, out IReadOnlyList<Word> stored))
+            {
+                foldScope.Hits++;
+                var replayed = new List<Word>(stored.Count);
+                foreach (Word storedOutput in stored)
+                    // Realizational rules are trail-exempt (no IsMorphologicalRuleApplicable gate), so a
+                    // successful application never advances PendingTrailPosition.
+                    replayed.Add(storedOutput.ReanchorSynthesisStep(input, trailConsuming: false));
+                return replayed;
+            }
+
+            var computed = ApplyUncached(input).ToList();
+            foldScope.Store(key, _rule, computed);
+            return computed;
+        }
+
+        // Everything SynthesisStateKey is audited against: the "at most once" and subsumption/blocking
+        // gates, per-allomorph MPR checks, pattern matching, unification.
+        private IEnumerable<Word> ApplyUncached(Word input)
+        {
             // RealizationalRule has no multipleApplication attribute, so it applies at most once per
             // word; otherwise a rule cascade that retries a matching rule against its own output would
             // never terminate.

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisFoldScope.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisFoldScope.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace SIL.Machine.Morphology.HermitCrab
+{
+    /// <summary>
+    /// Carrier for the synthesis fold-step memo (docs/hermitcrab-synthesis-fold-probes.md). Same shape as
+    /// <see cref="AnalysisScope"/>: one instance per <see cref="Morpher.ParseWord(string, out object)"/>
+    /// call, threaded through <see cref="Word.SynthesisFoldScope"/>, not installed while tracing or when
+    /// running with more than one degree of parallelism (plain <see cref="Dictionary{TKey,TValue}"/>, not
+    /// thread-safe).
+    /// <para>
+    /// A memo entry is keyed on (<see cref="SynthesisStateKey"/>, applied rule) and holds a SET of output
+    /// Words -- not one value -- because several allomorphs of one rule can legitimately all pattern-match
+    /// one input before a disjunctive break (see the doc comment on <c>SynthesisAffixProcessRule.Apply</c>'s
+    /// call to <c>SynthesisProbe.RecordApplications</c>, which records fold steps the same way for the same
+    /// reason). Stored Words are never handed to a caller directly: every read goes through
+    /// <see cref="Word.ReanchorSynthesisStep"/>, which re-parents the stored result onto the querying
+    /// candidate's own trail/non-head identity.
+    /// </para>
+    /// <para>
+    /// Only successful steps are stored, mirroring <see cref="SynthesisProbe.RecordApplications"/>: a
+    /// trail-position mismatch (<c>IsMorphologicalRuleApplicable</c> false) is an O(1) index-plus-reference
+    /// check the plan doc itself characterizes as "not 95% of anything" at ~29ns, so memoizing it would
+    /// spend a scarce entry slot buying almost nothing. Empty results *past* that cheap gate (a rule that
+    /// was trail-eligible but whose allomorphs all failed to unify/pattern-match) ARE stored, because
+    /// reaching that verdict is exactly the expensive work (unification, pattern matching) this memo exists
+    /// to share.
+    /// </para>
+    /// </summary>
+    internal sealed class SynthesisFoldScope
+    {
+        // Same cap philosophy as AnalysisScope.MaxMemoEntries: a coarse backstop, not a figure derived from
+        // measured memory. Correctness never depends on it -- past the cap, new fold steps are simply
+        // computed and returned unmemoized, same as when the scope itself is null.
+        private const int MaxMemoEntries = 100_000;
+
+        private readonly Dictionary<SynthesisFoldStepKey, IReadOnlyList<Word>> _memo =
+            new Dictionary<SynthesisFoldStepKey, IReadOnlyList<Word>>();
+
+        /// <summary>Per-parse hit count, folded into the owning Morpher when the parse ends.</summary>
+        public int Hits { get; set; }
+
+        public bool TryGet(SynthesisStateKey key, IMorphologicalRule rule, out IReadOnlyList<Word> outputs)
+        {
+            return _memo.TryGetValue(new SynthesisFoldStepKey(key, rule), out outputs);
+        }
+
+        public void Store(SynthesisStateKey key, IMorphologicalRule rule, IReadOnlyList<Word> outputs)
+        {
+            if (_memo.Count >= MaxMemoEntries)
+                return;
+            _memo[new SynthesisFoldStepKey(key, rule)] = outputs;
+        }
+
+        private readonly struct SynthesisFoldStepKey : IEquatable<SynthesisFoldStepKey>
+        {
+            private readonly SynthesisStateKey _state;
+            private readonly IMorphologicalRule _rule;
+            private readonly int _hash;
+
+            public SynthesisFoldStepKey(SynthesisStateKey state, IMorphologicalRule rule)
+            {
+                _state = state;
+                _rule = rule;
+                _hash = (state.GetHashCode() * 397) ^ (rule?.GetHashCode() ?? 0);
+            }
+
+            public bool Equals(SynthesisFoldStepKey other) => _rule == other._rule && _state.Equals(other._state);
+
+            public override bool Equals(object obj) => obj is SynthesisFoldStepKey k && Equals(k);
+
+            public override int GetHashCode() => _hash;
+        }
+    }
+}

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisFoldScope.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisFoldScope.cs
@@ -41,15 +41,27 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// <summary>Per-parse hit count, folded into the owning Morpher when the parse ends.</summary>
         public int Hits { get; set; }
 
+        // Diagnostic totals for the A/B harness: distinguishes "the memo never hits" (the idea is dead)
+        // from "the memo hits but the key costs more than the step it saves" (the key is the problem).
+        // Free-running; a harness reads the delta.
+        internal static long DiagHits;
+        internal static long DiagStores;
+        internal static long DiagLookups;
+
         public bool TryGet(SynthesisStateKey key, IMorphologicalRule rule, out IReadOnlyList<Word> outputs)
         {
-            return _memo.TryGetValue(new SynthesisFoldStepKey(key, rule), out outputs);
+            DiagLookups++;
+            bool hit = _memo.TryGetValue(new SynthesisFoldStepKey(key, rule), out outputs);
+            if (hit)
+                DiagHits++;
+            return hit;
         }
 
         public void Store(SynthesisStateKey key, IMorphologicalRule rule, IReadOnlyList<Word> outputs)
         {
             if (_memo.Count >= MaxMemoEntries)
                 return;
+            DiagStores++;
             _memo[new SynthesisFoldStepKey(key, rule)] = outputs;
         }
 

--- a/src/SIL.Machine.Morphology.HermitCrab/SynthesisStateKey.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/SynthesisStateKey.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using SIL.Machine.Annotations;
+using SIL.Machine.FeatureModel;
+
+namespace SIL.Machine.Morphology.HermitCrab
+{
+    /// <summary>
+    /// Identity of a synthesis fold-step input, for <see cref="SynthesisFoldScope"/>
+    /// (docs/hermitcrab-synthesis-fold-probes.md). Two Words with an equal key must make an identical
+    /// decision -- same output set -- for the same rule in every synthesis-side class the fold can invoke;
+    /// that is the memo's correctness contract, so this key-completeness audit has to be re-run whenever a
+    /// <c>Synthesis*.cs</c> rule or <c>Allomorph</c>/<c>Morpher.IsWordValid</c> changes.
+    /// <para>
+    /// <b>Not a starting point: <c>SynthesisProbe</c>'s P1c fingerprint.</b> That fingerprint is a
+    /// *measurement* key (docs/hermitcrab-synthesis-fold-probes.md section 3) and is unsound as a memo key
+    /// for exactly one reason, recorded as a trap in the plan doc and reconfirmed by the N1 census
+    /// retraction (section 7): it carries <c>PendingTrailPosition</c>, an integer index, and no
+    /// remaining-trail *content*. Two candidates at the same index with different pending rule sequences
+    /// compare equal under it. For a per-step measurement that is fine -- the "applied rule" half of
+    /// <c>FoldStepKey</c> already tells you which single rule was attempted. For a memo that *skips real
+    /// work and hands back a stored result*, it silently drops the distinct continuation the omitted trail
+    /// content represents: two states that will diverge on the very next step get merged, and the rarer
+    /// path's parse is lost. This key fixes exactly that gap (see <see cref="_pendingTrail"/> below) and is
+    /// otherwise structurally close to the P1c fingerprint, because that fingerprint's own field list is
+    /// itself the result of an audit against these same classes.
+    /// </para>
+    /// <para>
+    /// <b>Not <c>Word.ValueEquals</c>.</b> (<c>Word.cs</c>) compares shape, realizational FS, non-heads,
+    /// stratum, root allomorph, trail, index and the final-rule flag, and omits
+    /// <c>SyntacticFeatureStruct</c>, MPR features, and disjunctive allomorph indices -- all three read
+    /// below. It also includes non-heads, which nothing this memo covers reads or writes (see field list).
+    /// </para>
+    /// <para>
+    /// Field-by-field justification, audited against <see cref="MorphologicalRules.SynthesisAffixProcessRule"/>,
+    /// <see cref="MorphologicalRules.SynthesisRealizationalAffixProcessRule"/>, <see cref="SynthesisStratumRule"/>,
+    /// <see cref="SynthesisAffixTemplateRule"/>, <see cref="SynthesisAffixTemplatesRule"/>,
+    /// <see cref="Allomorph.IsWordValid(Morpher, Word)"/>, and the private <c>Morpher.IsWordValid(Word)</c>:
+    /// <list type="bullet">
+    /// <item><b>Shape</b> (<see cref="Word.Shape"/>, compared/hashed via <c>ValueEquals</c>/
+    /// <c>GetFrozenHashCode</c>) -- every rule's pattern match reads it
+    /// (<c>SynthesisAffixProcessAllomorphRuleSpec</c>), and <c>Allomorph.IsWordValid</c>'s environment and
+    /// disjunctive-allomorph checks read the surrounding shape context. <c>Shape.ValueEquals</c> recurses
+    /// into every annotation's <c>FeatureStruct</c>, including each "Morph" annotation's MorphID and
+    /// Allomorph feature values -- so two candidates whose shape differs only in which
+    /// <c>_mruleAppCount</c>-derived MorphID got stamped on an otherwise-identical morph (a real hazard:
+    /// realizational rules are trail-exempt and can fire a different number of times along two paths that
+    /// otherwise converge) are already caught here, with no separate field needed. This is also why
+    /// <c>Allomorphs</c>/<c>ObligatorySyntacticFeatures</c> (both read by <c>Morpher.IsWordValid</c>) do not
+    /// need their own field: the allomorph-ID set embedded in every Morph annotation's FeatureStruct pins
+    /// <c>_allomorphs</c>' key set (and, since <c>Allomorph</c> objects are grammar-level singletons per ID,
+    /// its values too), and <c>ObligatorySyntacticFeatures</c> is a deterministic union of
+    /// <c>rule.ObligatorySyntacticFeatures</c> over the rules with a positive count in
+    /// <see cref="_appliedRuleCounts"/>, which is already a field below.</item>
+    /// <item><b>SyntacticFeatureStruct</b> -- read by every rule's <c>RequiredSyntacticFeatureStruct.Unify</c>
+    /// (<c>SynthesisAffixProcessRule.cs</c>, <c>SynthesisRealizationalAffixProcessRule.cs</c>), by
+    /// <c>SynthesisAffixTemplatesRule</c>'s <c>IsUnifiable</c>/<c>ChooseInflectionalStem</c> checks, and by
+    /// <c>Morpher.IsWordValid</c>'s <c>RealizationalFeatureStruct.IsUnifiable</c> and obligatory-feature
+    /// checks. Hashed with a deliberately weak, freeze-free hash (mirroring
+    /// <c>SynthesisProbe.SyntacticFeatureStructWeakHash</c>): <c>Word.FreezeImpl</c> does not freeze this
+    /// field (<c>AnalysisAffixTemplateRule.Apply</c> mutates it on already-frozen Words), so
+    /// <c>GetFrozenHashCode</c> is unavailable and must not be forced by freezing it here as a side effect.
+    /// Correctness lives entirely in <see cref="Equals"/>, which always does the real
+    /// <c>FeatureStruct.ValueEquals</c>; a hash collision only costs a linear bucket scan.</item>
+    /// <item><b>RealizationalFeatureStruct</b> -- read by <c>SynthesisRealizationalAffixProcessRule</c>'s
+    /// <c>Subsumes</c>/<c>IsBlocked</c> checks, by <c>SynthesisAffixTemplatesRule.ChooseInflectionalStem</c>
+    /// and its own <c>IsUnifiable</c> gate, and by <c>Morpher.IsWordValid</c>'s <c>IsUnifiable</c> check.</item>
+    /// <item><b>MprFeatures</b> -- read by every allomorph's <c>RequiredMprFeatures</c>/<c>ExcludedMprFeatures</c>
+    /// check in both memoized rule classes.</item>
+    /// <item><b>RootAllomorph</b> (reference identity) -- <c>SynthesisAffixProcessRule</c>'s
+    /// <c>RequiredStemName</c> check reads <c>input.RootAllomorph.StemName</c> directly, and
+    /// <c>SynthesisAffixTemplatesRule.ChooseInflectionalStem</c> reads
+    /// <c>input.RootAllomorph.Morpheme</c>'s family/stratum.</item>
+    /// <item><b>DisjunctiveAllomorphIndices</b> -- read by <c>Allomorph.IsWordValid</c> via
+    /// <c>GetDisjunctiveAllomorphApplications</c>; two words differing only here can validly disagree on
+    /// whether a later allomorph is blocked. Compared as a dictionary of sets (order-independent both
+    /// within each set and across morph IDs), matching how it is written
+    /// (<c>Word.MorphologicalRuleApplied</c>'s <c>UnionWith</c>).</item>
+    /// <item><b>AppliedRuleCounts</b> -- backs every rule's <c>MaxApplicationCount</c> gate
+    /// (<c>SynthesisAffixProcessRule.cs</c>) and realizational's "at most once" gate
+    /// (<c>SynthesisRealizationalAffixProcessRule.cs</c>), and -- see the Shape item above -- transitively
+    /// pins <c>ObligatorySyntacticFeatures</c>. Compared as a dictionary (order-independent), matching how
+    /// unapplication counts are compared on the analysis side.</item>
+    /// <item><b>IsPartial</b> -- read by <c>SynthesisAffixProcessRule</c>'s final-template-adjacency gates
+    /// and by <c>SynthesisAffixTemplatesRule</c>'s applicable-template / no-template-fired branches.</item>
+    /// <item><b>IsLastAppliedRuleFinal</b> -- read by the same final-template-adjacency gates and by
+    /// <c>SynthesisStratumRule.Apply</c>'s own final-rule check
+    /// (<c>mruleOutWord.IsLastAppliedRuleFinal ?? false</c>).</item>
+    /// <item><b>Stratum</b> -- <c>SynthesisStratumRule.Apply</c> gates on
+    /// <c>input.RootAllomorph.Morpheme.Stratum.Depth &gt; _stratum.Depth</c>, and
+    /// <c>HasRemainingRulesFromStratum</c> reads it via <c>curRule.Stratum</c>.</item>
+    /// <item><b>Pending trail content</b> (<see cref="_pendingTrail"/>, an ORDERED sequence, not a
+    /// multiset -- unlike <see cref="AnalysisStateKey"/>'s unapplication counts, order here is exactly what
+    /// determines which rule fires next, so two equal-length pending trails with the rules in a different
+    /// order are genuinely different states) -- <c>IsMorphologicalRuleApplicable</c> and
+    /// <c>HasRemainingRulesFromStratum</c> read only its first (current) entry to decide *this* step, but
+    /// the memo also has to guarantee the *next* step -- run against this step's stored output, replayed
+    /// onto a different query candidate -- sees the correct rest of the trail. This is the field the P1c
+    /// fingerprint deliberately omits; see the class remarks above.</item>
+    /// </list>
+    /// Deliberately excluded, with the reason a rule-read audit does not license including them:
+    /// <list type="bullet">
+    /// <item>The already-consumed trail suffix (entries past the pending prefix) and the non-head list --
+    /// never read by any rule again once passed, only by <c>MorphemesInApplicationOrder</c> on a finished
+    /// result. <see cref="Word.ReanchorSynthesisStep"/> splices both from the query candidate rather than
+    /// the stored one, exactly because the key does not (and must not, to keep sharing meaningful) pin them
+    /// down.</item>
+    /// <item><c>_mruleAppCount</c> and MorphID strings -- bookkeeping for a per-word morph-annotation
+    /// ordinal, not a decision input to any rule; already transitively pinned by Shape equality (see the
+    /// Shape item above), so adding it explicitly would be redundant, not more complete.</item>
+    /// <item>Compounding-rule state (<c>CurrentNonHead</c>/non-heads) -- read only by
+    /// <see cref="MorphologicalRules.SynthesisCompoundingRule"/>, which this memo does not intercept (it is
+    /// out of the audited class list above, and out of what <c>SynthesisProbe</c>'s P1c ratio measured).
+    /// Compounding-driven fold steps always fall through unmemoized.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    internal readonly struct SynthesisStateKey : IEquatable<SynthesisStateKey>
+    {
+        private readonly Shape _shape;
+        private readonly FeatureStruct _syntacticFS;
+        private readonly FeatureStruct _realizationalFS;
+        private readonly MprFeatureSet _mprFeatures;
+        private readonly RootAllomorph _rootAllomorph;
+        private readonly IReadOnlyDictionary<string, HashSet<int>> _disjunctiveAllomorphIndices;
+        private readonly IReadOnlyDictionary<IMorphologicalRule, int> _appliedRuleCounts;
+        private readonly bool _isPartial;
+        private readonly bool? _isLastAppliedRuleFinal;
+        private readonly Stratum _stratum;
+        private readonly IMorphologicalRule[] _pendingTrail;
+        private readonly int _hashCode;
+
+        /// <summary>
+        /// Keys <paramref name="word"/>. A named factory to match <c>AnalysisStateKey.PinAndKey</c>'s
+        /// style, though unlike that key this one never mutates <paramref name="word"/>: it deliberately
+        /// avoids freezing <c>SyntacticFeatureStruct</c> (see the class remarks).
+        /// </summary>
+        public static SynthesisStateKey PinAndKey(Word word)
+        {
+            return new SynthesisStateKey(word);
+        }
+
+        private SynthesisStateKey(Word word)
+        {
+            if (!word.IsFrozen)
+                throw new ArgumentException(
+                    "The word must be frozen before it can be used as a memo key.",
+                    nameof(word)
+                );
+
+            _shape = word.Shape;
+            _syntacticFS = word.SyntacticFeatureStruct;
+            _realizationalFS = word.RealizationalFeatureStruct;
+            _mprFeatures = word.MprFeatures;
+            _rootAllomorph = word.RootAllomorph;
+            _disjunctiveAllomorphIndices = word.DisjunctiveAllomorphIndices;
+            _appliedRuleCounts = word.AppliedRuleCounts;
+            _isPartial = word.IsPartial;
+            _isLastAppliedRuleFinal = word.IsLastAppliedRuleFinal;
+            _stratum = word.Stratum;
+
+            int pendingLength = word.PendingTrailPosition + 1;
+            _pendingTrail = pendingLength <= 0 ? Array.Empty<IMorphologicalRule>() : new IMorphologicalRule[pendingLength];
+            for (int i = 0; i < pendingLength; i++)
+                _pendingTrail[i] = word.MorphologicalRuleTrail[i];
+
+            _realizationalFS.Freeze();
+
+            int hash = 17;
+            hash = hash * 31 + _shape.GetFrozenHashCode();
+            hash = hash * 31 + SyntacticFeatureStructWeakHash(_syntacticFS);
+            hash = hash * 31 + _realizationalFS.GetFrozenHashCode();
+            hash = hash * 31 + UnorderedSetHash(_mprFeatures);
+            hash = hash * 31 + (_rootAllomorph?.GetHashCode() ?? 0);
+            hash = hash * 31 + UnorderedDictHash(_disjunctiveAllomorphIndices, UnorderedSetHash);
+            hash = hash * 31 + UnorderedDictHash(_appliedRuleCounts, v => v);
+            hash = hash * 31 + _isPartial.GetHashCode();
+            hash = hash * 31 + _isLastAppliedRuleFinal.GetHashCode();
+            hash = hash * 31 + (_stratum?.GetHashCode() ?? 0);
+            foreach (IMorphologicalRule rule in _pendingTrail)
+                hash = hash * 31 + (rule?.GetHashCode() ?? 0);
+            _hashCode = hash;
+        }
+
+        public override int GetHashCode() => _hashCode;
+
+        public override bool Equals(object obj) => obj is SynthesisStateKey other && Equals(other);
+
+        public bool Equals(SynthesisStateKey other)
+        {
+            if (_hashCode != other._hashCode)
+                return false;
+            if (_isPartial != other._isPartial || _isLastAppliedRuleFinal != other._isLastAppliedRuleFinal)
+                return false;
+            if (!ReferenceEquals(_stratum, other._stratum) || !ReferenceEquals(_rootAllomorph, other._rootAllomorph))
+                return false;
+            if (!PendingTrailEqual(_pendingTrail, other._pendingTrail))
+                return false;
+            if (!_shape.ValueEquals(other._shape))
+                return false;
+            if (!_syntacticFS.ValueEquals(other._syntacticFS) || !_realizationalFS.ValueEquals(other._realizationalFS))
+                return false;
+            if (!_mprFeatures.SetEquals(other._mprFeatures))
+                return false;
+            if (!DictEquals(_appliedRuleCounts, other._appliedRuleCounts, (x, y) => x == y))
+                return false;
+            return DictEquals(
+                _disjunctiveAllomorphIndices,
+                other._disjunctiveAllomorphIndices,
+                (x, y) => x.SetEquals(y)
+            );
+        }
+
+        private static bool PendingTrailEqual(IMorphologicalRule[] a, IMorphologicalRule[] b)
+        {
+            if (a.Length != b.Length)
+                return false;
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                    return false;
+            }
+            return true;
+        }
+
+        // FeatureStruct.GetFrozenHashCode() throws unless frozen, and SyntacticFeatureStruct is
+        // deliberately never frozen by this key (see class remarks). Weak but always-safe: Equals always
+        // does the real ValueEquals, so a collision only costs a linear bucket scan, never a false merge.
+        private static int SyntacticFeatureStructWeakHash(FeatureStruct fs)
+        {
+            int acc = 0;
+            foreach (Feature f in fs.Features)
+                acc ^= f.GetHashCode();
+            return acc;
+        }
+
+        private static int UnorderedSetHash<T>(IEnumerable<T> items)
+        {
+            int acc = 0;
+            foreach (T item in items)
+                acc ^= item?.GetHashCode() ?? 0;
+            return acc;
+        }
+
+        private static int UnorderedDictHash<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue> dict,
+            Func<TValue, int> valueHash
+        )
+        {
+            int acc = 0;
+            foreach (KeyValuePair<TKey, TValue> kvp in dict)
+                acc ^= ((kvp.Key?.GetHashCode() ?? 0) * 397) ^ valueHash(kvp.Value);
+            return acc;
+        }
+
+        private static bool DictEquals<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue> a,
+            IReadOnlyDictionary<TKey, TValue> b,
+            Func<TValue, TValue, bool> valueEquals
+        )
+        {
+            if (a.Count != b.Count)
+                return false;
+            foreach (KeyValuePair<TKey, TValue> kvp in a)
+            {
+                if (!b.TryGetValue(kvp.Key, out TValue otherValue) || !valueEquals(kvp.Value, otherValue))
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/SIL.Machine.Morphology.HermitCrab/Word.cs
+++ b/src/SIL.Machine.Morphology.HermitCrab/Word.cs
@@ -96,6 +96,7 @@ namespace SIL.Machine.Morphology.HermitCrab
             _isPartial = word._isPartial;
             CurrentTrace = word.CurrentTrace;
             AnalysisScope = word.AnalysisScope;
+            SynthesisFoldScope = word.SynthesisFoldScope;
             _disjunctiveAllomorphIndices = word._disjunctiveAllomorphIndices.ToDictionary(
                 kvp => kvp.Key,
                 kvp => new HashSet<int>(kvp.Value)
@@ -227,6 +228,18 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// not pin the per-parse tables.
         /// </summary>
         internal AnalysisScope AnalysisScope { get; set; }
+
+        /// <summary>
+        /// Carrier for the synthesis fold-step memo (docs/hermitcrab-synthesis-fold-probes.md). Same
+        /// contract as <see cref="AnalysisScope"/>: reference-shared through clones, excluded from
+        /// <c>FreezeImpl</c>/<c>ValueEquals</c>, null unless <see cref="Morpher.UseSynthesisFoldMemo"/> is
+        /// on and the parse is running sequentially and untraced. One instance per
+        /// <see cref="Morpher.ParseWord(string, out object)"/> call, installed on every alternative that
+        /// enters <c>_synthesisRule.Apply</c> in <c>Morpher.SynthesizeSequential</c> -- shared across every
+        /// analysis word's alternatives for that one surface-word parse, which is exactly the scope P1c/N1
+        /// measured sharing over.
+        /// </summary>
+        internal SynthesisFoldScope SynthesisFoldScope { get; set; }
 
         public bool IsPartial
         {
@@ -429,6 +442,18 @@ namespace SIL.Machine.Morphology.HermitCrab
         /// </summary>
         internal int PendingTrailPosition => _mruleAppIndex;
 
+        /// <summary>
+        /// The full morphological-rule trail list, for <see cref="SynthesisStateKey"/>. Read together with
+        /// <see cref="PendingTrailPosition"/>: entries at indices <c>0..PendingTrailPosition</c> are the
+        /// still-pending trail content a synthesis step's continuation depends on (what
+        /// <see cref="SynthesisProbe"/>'s P1c fingerprint omits -- position only, no content, see the plan
+        /// doc's trap #1); entries past <c>PendingTrailPosition</c> are already consumed and never read
+        /// again by any rule, only by <see cref="MorphemesInApplicationOrder"/> on a fully-finished result.
+        /// This list itself never mutates during synthesis -- <see cref="MorphologicalRuleApplied"/> only
+        /// moves <see cref="PendingTrailPosition"/> -- so exposing the live list is safe.
+        /// </summary>
+        internal IReadOnlyList<IMorphologicalRule> MorphologicalRuleTrail => _mruleApps;
+
         internal Word CurrentNonHead
         {
             get
@@ -571,6 +596,88 @@ namespace SIL.Machine.Morphology.HermitCrab
         internal List<Word> CloneNonHeadsForReplay()
         {
             return new List<Word>(_nonHeadApps.CloneItems());
+        }
+
+        /// <summary>
+        /// Grafts a memoized synthesis fold-step result (<c>this</c>, produced by applying one rule to some
+        /// <c>storedInput</c>) onto <paramref name="queryInput"/>, whose <see cref="SynthesisStateKey"/>
+        /// equals <c>storedInput</c>'s. The single-step mirror of <see cref="ReplayOnto"/> -- see
+        /// docs/hermitcrab-synthesis-fold-probes.md, "What to build" item 2.
+        /// <para>
+        /// Sound because <see cref="SynthesisStateKey"/> equality guarantees <c>storedInput</c> and
+        /// <paramref name="queryInput"/> agree on everything the step read (Shape -- including every morph
+        /// annotation's MorphID/Allomorph feature values, so this word's own already-marked
+        /// <c>_allomorphs</c> and the new step's MorphID stamp are already correct as computed -- both
+        /// FeatureStructs, MprFeatures, disjunctive-allomorph indices, per-rule applied counts, IsPartial,
+        /// IsLastAppliedRuleFinal, Stratum, and the pending trail content) and on everything that field
+        /// determines transitively (<c>ObligatorySyntacticFeatures</c> is a deterministic union over which
+        /// rules have applied at least once, i.e. over <c>AppliedRuleCounts</c>' support). So this word's
+        /// own computed content carries over UNCHANGED: it is exactly what re-running the step on
+        /// <paramref name="queryInput"/> would have produced too.
+        /// </para>
+        /// <para>
+        /// Two things do NOT transfer, because they are exactly what the key -- correctly -- does not pin
+        /// down, and because neither of the two rule classes this memo covers
+        /// (<see cref="MorphologicalRules.SynthesisAffixProcessRule"/>,
+        /// <see cref="MorphologicalRules.SynthesisRealizationalAffixProcessRule"/>) touches them:
+        /// <list type="bullet">
+        /// <item>The already-consumed suffix of the morphological-rule trail (entries past
+        /// <paramref name="queryInput"/>'s <see cref="PendingTrailPosition"/>). No rule reads it again, but
+        /// <c>MorphemesInApplicationOrder</c> walks the whole list on a finished result, so it must be
+        /// <paramref name="queryInput"/>'s own history, not the stored candidate's.</item>
+        /// <item>The non-head list -- neither memoized rule class calls <c>NonHeadUnapplied</c>, so it must
+        /// stay exactly what <paramref name="queryInput"/> already had.</item>
+        /// </list>
+        /// Both are spliced from <paramref name="queryInput"/>, this word's own copies discarded.
+        /// </para>
+        /// <para>
+        /// <b>Blocking exception.</b> <c>Apply</c>'s <c>CheckBlocking</c> branch can replace a step's output
+        /// with a wholly fresh <see cref="Word"/> built from a sibling <c>LexEntry</c> (<see cref="CheckBlocking"/>),
+        /// which is born with an EMPTY morphological-rule trail and no reference to the input that produced
+        /// it at all -- it is not a continuation, it overrides one. Reaching this method's call sites only
+        /// happens once <see cref="IsMorphologicalRuleApplicable"/> has already required a non-empty trail on
+        /// the real input, so an empty trail on <c>this</c> can only mean blocking fired, never a
+        /// coincidentally-empty ordinary continuation. Such a result is already correct for any
+        /// same-key query and is returned as-is, unspliced: grafting <paramref name="queryInput"/>'s trail
+        /// onto it would fabricate morphemes <c>MorphemesInApplicationOrder</c> was never meant to report
+        /// and could make <c>Morpher.IsWordValid</c>'s <c>IsAllMorphologicalRulesApplied</c> check reject a
+        /// word the unmemoized engine would have accepted.
+        /// </para>
+        /// </summary>
+        /// <param name="queryInput">
+        /// The word that hit the memo. Its trail (advanced by exactly this step) and non-heads become this
+        /// result's identity.
+        /// </param>
+        /// <param name="trailConsuming">
+        /// True for a trail-driven rule (<see cref="MorphologicalRules.SynthesisAffixProcessRule"/>), which
+        /// always advances <see cref="PendingTrailPosition"/> by one once
+        /// <see cref="IsMorphologicalRuleApplicable"/> has already gated entry; false for a trail-exempt
+        /// realizational rule (<see cref="MorphologicalRules.SynthesisRealizationalAffixProcessRule"/>),
+        /// which never does. Mirrors exactly what <see cref="MorphologicalRuleApplied"/> itself would have
+        /// done to <paramref name="queryInput"/>.
+        /// </param>
+        internal Word ReanchorSynthesisStep(Word queryInput, bool trailConsuming)
+        {
+            // See the "Blocking exception" remarks above.
+            if (_mruleApps.Count == 0)
+                return this;
+
+            var clone = new Word(this, cloneNonHeadApps: false);
+
+            clone._mruleApps.Clear();
+            clone._mruleApps.AddRange(queryInput._mruleApps);
+            clone._mruleAppIndex = trailConsuming ? queryInput._mruleAppIndex - 1 : queryInput._mruleAppIndex;
+
+            clone._nonHeadApps.AddRange(queryInput._nonHeadApps.CloneItems());
+            clone._nonHeadAppIndex = queryInput._nonHeadAppIndex;
+
+            clone.CurrentTrace = queryInput.CurrentTrace;
+            clone.AnalysisScope = queryInput.AnalysisScope;
+            clone.SynthesisFoldScope = queryInput.SynthesisFoldScope;
+            clone.Source = queryInput;
+
+            clone.Freeze();
+            return clone;
         }
 
         public Allomorph GetAllomorph(Annotation<ShapeNode> morph)

--- a/tests/SIL.Machine.Morphology.HermitCrab.Tests/SynthesisFoldMemoVerification.cs
+++ b/tests/SIL.Machine.Morphology.HermitCrab.Tests/SynthesisFoldMemoVerification.cs
@@ -1,0 +1,368 @@
+#nullable disable
+using System.Diagnostics;
+using NUnit.Framework;
+using SIL.Machine.Morphology.HermitCrab.Conformance;
+
+namespace SIL.Machine.Morphology.HermitCrab;
+
+/// <summary>
+/// Memo-on/memo-off equality for <see cref="Morpher.UseSynthesisFoldMemo"/>
+/// (docs/hermitcrab-synthesis-fold-probes.md), the synthesis-side counterpart to
+/// <see cref="MemoCorpusVerification"/>. Both sides run at <c>maxDegreeOfParallelism: 1</c> -- the toggle
+/// only takes effect there -- so the only variable is the toggle itself.
+/// <para>
+/// Two gates: the 33 committed conformance fixtures (fast, synthetic, safe to run unconditionally) and a
+/// real corpus via the same env vars <see cref="MemoCorpusVerification"/> uses (this repo never commits
+/// real grammars or word lists). [Explicit] throughout, matching every other corpus/fixture-sweep test in
+/// this file's neighbourhood (<see cref="SynthesisFoldProbe"/>, <see cref="MemoCorpusVerification"/>): not
+/// part of CI, run manually.
+/// </para>
+/// <code>
+///   dotnet test --filter "FullyQualifiedName~SynthesisFoldMemoVerification.MemoOnMatchesMemoOff_AnalysisSetIdentical_AcrossConformanceFixtures"
+///
+///   $env:HC_MEMO_GRAMMAR = "...\sena-hc.xml"
+///   $env:HC_MEMO_WORDS   = "...\sena-words.txt"
+///   $env:HC_MEMO_MAX_WORDS = "60"
+///   $env:HC_MEMO_TIMEOUT_MS = "600000"
+///   dotnet test --filter "FullyQualifiedName~SynthesisFoldMemoVerification.MemoOnMatchesMemoOff_AnalysisSetIdentical_OnRealCorpus"
+/// </code>
+/// </summary>
+[TestFixture]
+[Explicit("Manual corpus/fixture verification; not part of CI. See docs/hermitcrab-synthesis-fold-probes.md.")]
+public class SynthesisFoldMemoVerification
+{
+    [Test]
+    public void MemoOnMatchesMemoOff_AnalysisSetIdentical_AcrossConformanceFixtures()
+    {
+        string fixturesRoot = Environment.GetEnvironmentVariable("HC_PROBE_FIXTURES_ROOT");
+        if (string.IsNullOrEmpty(fixturesRoot))
+            fixturesRoot = Path.Combine(RepositoryRoot(), "conformance");
+
+        List<Fixture> fixtures = Fixture.DiscoverAll(fixturesRoot);
+        Assert.That(fixtures, Is.Not.Empty, $"no fixtures discovered under {fixturesRoot}");
+
+        var divergences = new List<string>();
+        long totalHitsAcrossFixtures = 0;
+        var fixtureTimings = new List<(string Id, double OnMs, double OffMs, int Words)>();
+
+        foreach (Fixture fixture in fixtures)
+        {
+            Language language;
+            try
+            {
+                language = XmlLanguageLoader.Load(fixture.GrammarPath);
+            }
+            catch (Exception e)
+            {
+                TestContext.Out.WriteLine($"[{fixture.Id}] grammar failed to load: {e.GetType().Name} -- skipped");
+                continue;
+            }
+
+            var memoOff = new Morpher(new TraceManager(), language, maxDegreeOfParallelism: 1);
+            var memoOn = new Morpher(new TraceManager(), language, maxDegreeOfParallelism: 1)
+            {
+                UseSynthesisFoldMemo = true,
+            };
+
+            double onMs = 0;
+            double offMs = 0;
+            foreach (WordEntry entry in fixture.Words.Words)
+            {
+                var swOff = Stopwatch.StartNew();
+                List<string> offSignatures = Signatures(memoOff, entry.Word);
+                swOff.Stop();
+                offMs += swOff.Elapsed.TotalMilliseconds;
+
+                var swOn = Stopwatch.StartNew();
+                List<string> onSignatures = Signatures(memoOn, entry.Word);
+                swOn.Stop();
+                onMs += swOn.Elapsed.TotalMilliseconds;
+
+                if (!onSignatures.SequenceEqual(offSignatures))
+                {
+                    divergences.Add(
+                        $"[{fixture.Id}] {entry.Word}: memo-on={{{string.Join(",", onSignatures)}}} vs "
+                            + $"memo-off={{{string.Join(",", offSignatures)}}}"
+                    );
+                }
+            }
+
+            totalHitsAcrossFixtures += memoOn.SynthesisFoldHits;
+            fixtureTimings.Add((fixture.Id, onMs, offMs, fixture.Words.Words.Count));
+            TestContext.Out.WriteLine(
+                $"[{fixture.Id}] words={fixture.Words.Words.Count} memo-on={onMs:F2}ms memo-off={offMs:F2}ms "
+                    + $"hits={memoOn.SynthesisFoldHits} "
+                    + $"speedup={(onMs > 0 ? offMs / onMs : 0):F2}x"
+            );
+        }
+
+        TestContext.Out.WriteLine($"total synthesis fold-memo hits across all fixtures: {totalHitsAcrossFixtures}");
+        TestContext.Out.WriteLine("--- the two reliable fixtures from section 8 of the plan doc ---");
+        foreach (
+            string id in new[]
+            {
+                "edge-cases/deep-optional-affix-nesting",
+                "languages/suffixing-evidential-adjacency-chain",
+            }
+        )
+        {
+            var row = fixtureTimings.FirstOrDefault(r => r.Id == id);
+            if (row.Id == null)
+            {
+                TestContext.Out.WriteLine($"{id}: not found among discovered fixtures");
+                continue;
+            }
+            double speedup = row.OnMs > 0 ? row.OffMs / row.OnMs : 0;
+            double wallSaved = row.OffMs > 0 ? (1 - row.OnMs / row.OffMs) * 100 : 0;
+            TestContext.Out.WriteLine(
+                $"{id}: memo-off={row.OffMs:F2}ms memo-on={row.OnMs:F2}ms speedup={speedup:F2}x "
+                    + $"wall-clock-reduction={wallSaved:F1}%"
+            );
+        }
+
+        Assert.That(
+            divergences,
+            Is.Empty,
+            $"{divergences.Count} word(s) diverged between memo-on and memo-off across the 33 conformance "
+                + $"fixtures (showing up to 10): {string.Join(" | ", divergences.Take(10))}"
+        );
+    }
+
+    // One discarded warm-up per arm per word, then MeasuredReps interleaved samples of which the MINIMUM
+    // is kept, on FRESH Morphers built just for this test -- the correctness sweep above reuses one
+    // Morpher per fixture across every word, which is fine for equality but leaves memo tables/JIT state
+    // that would bias a single-pass timing comparison. Interleaving off/on per rep, rather than running
+    // all off reps then all on reps, means a one-off GC or JIT stall lands on both arms rather than
+    // whichever ran first. section 6.1 of the plan doc found sub-2ms fixtures unreliable to time at all;
+    // this is the section-8-style rigor those two numbers specifically need.
+    private const int WarmupReps = 1;
+    private const int MeasuredReps = 5;
+
+    [Test]
+    public void MeasuredSpeedup_OnTheTwoReliableFixtures()
+    {
+        string fixturesRoot = Environment.GetEnvironmentVariable("HC_PROBE_FIXTURES_ROOT");
+        if (string.IsNullOrEmpty(fixturesRoot))
+            fixturesRoot = Path.Combine(RepositoryRoot(), "conformance");
+        List<Fixture> fixtures = Fixture.DiscoverAll(fixturesRoot);
+
+        foreach (
+            string id in new[]
+            {
+                "edge-cases/deep-optional-affix-nesting",
+                "languages/suffixing-evidential-adjacency-chain",
+            }
+        )
+        {
+            Fixture fixture = fixtures.FirstOrDefault(f => f.Id == id);
+            if (fixture == null)
+            {
+                TestContext.Out.WriteLine($"{id}: not found among discovered fixtures");
+                continue;
+            }
+
+            Language language = XmlLanguageLoader.Load(fixture.GrammarPath);
+            var off = new Morpher(new TraceManager(), language, maxDegreeOfParallelism: 1);
+            var on = new Morpher(new TraceManager(), language, maxDegreeOfParallelism: 1)
+            {
+                UseSynthesisFoldMemo = true,
+            };
+
+            for (int w = 0; w < WarmupReps; w++)
+            {
+                foreach (WordEntry entry in fixture.Words.Words)
+                {
+                    Signatures(off, entry.Word);
+                    Signatures(on, entry.Word);
+                }
+            }
+
+            double offMin = double.MaxValue;
+            double offMax = 0;
+            double onMin = double.MaxValue;
+            for (int r = 0; r < MeasuredReps; r++)
+            {
+                var swOff = Stopwatch.StartNew();
+                foreach (WordEntry entry in fixture.Words.Words)
+                    Signatures(off, entry.Word);
+                swOff.Stop();
+
+                var swOn = Stopwatch.StartNew();
+                foreach (WordEntry entry in fixture.Words.Words)
+                    Signatures(on, entry.Word);
+                swOn.Stop();
+
+                double offMs = swOff.Elapsed.TotalMilliseconds;
+                double onMs = swOn.Elapsed.TotalMilliseconds;
+                offMin = Math.Min(offMin, offMs);
+                offMax = Math.Max(offMax, offMs);
+                onMin = Math.Min(onMin, onMs);
+            }
+
+            double speedup = onMin > 0 ? offMin / onMin : 0;
+            double wallSaved = offMin > 0 ? (1 - onMin / offMin) * 100 : 0;
+            // Off-arm (max - min) as a percentage of the off-arm floor: how much of any apparent delta
+            // could just be noise. A speedup implying less wall-clock reduction than this figure is not a
+            // result.
+            double offSpreadPct = offMin > 0 ? (offMax - offMin) / offMin * 100 : 0;
+            TestContext.Out.WriteLine(
+                $"{id}: memo-off(min of {MeasuredReps})={offMin:F2}ms memo-on(min of {MeasuredReps})={onMin:F2}ms "
+                    + $"speedup={speedup:F2}x wall-clock-reduction={wallSaved:F1}% "
+                    + $"off-arm-spread={offSpreadPct:F1}% hits={on.SynthesisFoldHits}"
+            );
+        }
+    }
+
+    [Test]
+    public void MemoOnMatchesMemoOff_AnalysisSetIdentical_OnRealCorpus()
+    {
+        (Language language, List<string> words) = Load();
+
+        var memoOff = new Morpher(new TraceManager(), language, maxDegreeOfParallelism: 1);
+        var memoOn = new Morpher(new TraceManager(), language, maxDegreeOfParallelism: 1)
+        {
+            UseSynthesisFoldMemo = true,
+        };
+        int timeoutMs = int.TryParse(Environment.GetEnvironmentVariable("HC_MEMO_TIMEOUT_MS"), out int t)
+            ? t
+            : 5000;
+
+        var perWordTimes = new List<(string Word, double OnMs, double OffMs)>();
+        var divergences = new List<string>();
+        var timedOut = new List<string>();
+        int noParseBoth = 0;
+
+        foreach (string word in words)
+        {
+            List<string> onSignatures;
+            List<string> offSignatures;
+            double onMs;
+            double offMs;
+            try
+            {
+                var swOff = Stopwatch.StartNew();
+                offSignatures = RunWithTimeout(() => Signatures(memoOff, word), timeoutMs);
+                swOff.Stop();
+                offMs = swOff.Elapsed.TotalMilliseconds;
+
+                var swOn = Stopwatch.StartNew();
+                onSignatures = RunWithTimeout(() => Signatures(memoOn, word), timeoutMs);
+                swOn.Stop();
+                onMs = swOn.Elapsed.TotalMilliseconds;
+            }
+            catch (TimeoutException)
+            {
+                timedOut.Add(word);
+                continue;
+            }
+            perWordTimes.Add((word, onMs, offMs));
+
+            if (onSignatures.Count == 0 && offSignatures.Count == 0)
+                noParseBoth++;
+
+            if (!onSignatures.SequenceEqual(offSignatures))
+            {
+                divergences.Add(
+                    $"{word}: memo-on={{{string.Join(",", onSignatures)}}} vs "
+                        + $"memo-off={{{string.Join(",", offSignatures)}}}"
+                );
+            }
+
+            TestContext.Out.WriteLine(
+                $"{word}: memo-off={offMs:F1}ms memo-on={onMs:F1}ms "
+                    + $"speedup={(onMs > 0 ? offMs / onMs : 0):F2}x hits-so-far={memoOn.SynthesisFoldHits}"
+            );
+        }
+
+        double totalOnMs = perWordTimes.Sum(x => x.OnMs);
+        double totalOffMs = perWordTimes.Sum(x => x.OffMs);
+        TestContext.Out.WriteLine($"words attempted: {words.Count}, timed out (>{timeoutMs}ms): {timedOut.Count}");
+        TestContext.Out.WriteLine($"words with no parse on both sides: {noParseBoth}");
+        TestContext.Out.WriteLine(
+            $"wall-clock: memo-on total {totalOnMs:F1} ms vs memo-off total {totalOffMs:F1} ms "
+                + $"({(totalOnMs > 0 ? totalOffMs / totalOnMs : 0):F2}x)"
+        );
+        TestContext.Out.WriteLine($"synthesis fold-memo hits (final Morpher totals): {memoOn.SynthesisFoldHits}");
+        if (timedOut.Count > 0)
+        {
+            TestContext.Out.WriteLine(
+                $"timed-out words (excluded from the equality gate above): {string.Join(", ", timedOut)}"
+            );
+        }
+
+        Assert.That(
+            divergences,
+            Is.Empty,
+            $"{divergences.Count} word(s) diverged between memo-on and memo-off "
+                + $"(showing up to 10): {string.Join(" | ", divergences.Take(10))}"
+        );
+    }
+
+    // Some conformance fixtures (e.g. edge-cases/simultaneous-epenthesis-cascade) are deliberately built
+    // so that a CORRECT C# engine throws -- InvalidShapeException for an out-of-inventory character (as
+    // Morpher.AnalyzeWord already tolerates) and InfiniteLoopException for a rewrite-rule runaway the
+    // engine's own hard cap catches. Neither is a memo concern: both are thrown well outside the
+    // memoized region (character-table lookup and post-fold phonological rewriting respectively). Rather
+    // than special-case fixture ids, any such crash is folded into a one-element sentinel signature so
+    // memo-on/memo-off comparison still works uniformly -- if only one side crashes, or the two sides
+    // crash with different exception types, that sentinel mismatch surfaces as a real divergence.
+    private static List<string> Signatures(Morpher morpher, string word)
+    {
+        try
+        {
+            return morpher
+                .ParseWord(word)
+                .Select(MorpherTests.WordAnalysisSignature)
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToList();
+        }
+        catch (InvalidShapeException)
+        {
+            return new List<string>();
+        }
+        catch (Exception e) when (e is InfiniteLoopException or global::SIL.Machine.Rules.MaxAlternativesExceededException)
+        {
+            return new List<string> { $"<<CRASH:{e.GetType().Name}>>" };
+        }
+    }
+
+    // See MemoCorpusVerification.RunWithTimeout for why this cannot cooperatively cancel.
+    private static T RunWithTimeout<T>(Func<T> action, int timeoutMs)
+    {
+        Task<T> task = Task.Run(action);
+        if (!task.Wait(timeoutMs))
+            throw new TimeoutException();
+        return task.Result;
+    }
+
+    private static string RepositoryRoot()
+    {
+        string directory = TestContext.CurrentContext.TestDirectory;
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory, "conformance", "constructs.txt")))
+                return directory;
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        Assert.Fail("Could not locate the repository root.");
+        return string.Empty;
+    }
+
+    private static (Language, List<string>) Load()
+    {
+        string grammarPath = Environment.GetEnvironmentVariable("HC_MEMO_GRAMMAR");
+        string wordsPath = Environment.GetEnvironmentVariable("HC_MEMO_WORDS");
+        if (string.IsNullOrEmpty(grammarPath) || string.IsNullOrEmpty(wordsPath))
+            Assert.Ignore("set HC_MEMO_GRAMMAR and HC_MEMO_WORDS");
+
+        int maxWords = int.TryParse(Environment.GetEnvironmentVariable("HC_MEMO_MAX_WORDS"), out int mw) ? mw : 60;
+        Language language = XmlLanguageLoader.Load(grammarPath);
+        List<string> words = File.ReadAllLines(wordsPath)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .Take(maxWords)
+            .ToList();
+        return (language, words);
+    }
+}


### PR DESCRIPTION
Stacked on #488. **This is the evidence that closes a family of optimizations. It is not proposed as a performance feature.**

#488 measured 3.22x and 8.10x shareable synthesis fold steps, with ~50%% wall-clock ceilings on the two conformance fixtures large enough to time reliably, reproduced across two independent runs. This branch builds it.

**It is correct.** `SynthesisStateKey` carries the ordered remaining trail plus shape, syntactic FS, realizational FS, MPR set, root allomorph, disjunctive allomorph indices, applied counts, `IsPartial`, `IsLastAppliedRuleFinal` and stratum — each field justified in the doc comment against the code that reads it. Stored outputs are re-anchored rather than handed over with a foreign trail embedded. Steps are set-valued, because realizational rules are trail-exempt. Off by default. **Parity: 0 divergences across all 33 conformance fixtures.**

**It does not pay.** Warm-up discarded, min of 5 interleaved samples per arm:

| fixture | predicted | realised | memo hits | off-arm noise |
| --- | --- | --- | --- | --- |
| deep-optional-affix-nesting | 50.4%% (~2x) | **0.96x** (4.5%% slower) | **0** | 38.6%% |
| suffixing-evidential-adjacency-chain | 52.0%% (~2x) | 1.06x | 2,682 | 21.9%% |

`hits = 0` on the fixture with the largest reliable sample and the highest ceiling. With a trail-complete key the memo never fires there; the regression is key-construction cost with no payoff.

**Why, and why it generalises.** A sound key must carry the remaining trail, so two candidates have to agree on their entire future to share a step. That is the third independent route to the same result:

| measurement | key | apparent | sound |
| --- | --- | --- | --- |
| synthesis-input dedupe | order-insensitive | 9,774x | 15-40%% |
| fold-entry census | trail position only | 6,476x | not established |
| fold-step sharing (here) | trail position only | 3.22x / 8.10x | **hits = 0** |

**The redundancy is apparent, not real. The trail is what makes each step distinct, and every measurement showing large shareable work is measuring a key that omits it.** Packed parse forests, fold-step sharing and synthesis-input dedupe all require distinct derivations to converge on a genuinely identical state. In this engine they do not converge — the same fact as the rules being non-order-invariant, seen from the other side.

**Disposition.** Recorded as row 5 in `docs/hermitcrab-optimization-ledger.md`. Merge only if you want the implementation in tree as executable proof; otherwise close and keep the branch. Either way the ledger row is the durable artifact, and it lives in #488.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/489)
<!-- Reviewable:end -->
