### PR TITLE
Fix bug with marker location prediction

### DIFF
--- a/src/SIL.Machine/Corpora/PlaceMarkersUsfmUpdateBlockHandler.cs
+++ b/src/SIL.Machine/Corpora/PlaceMarkersUsfmUpdateBlockHandler.cs
@@ -364,7 +364,7 @@ namespace SIL.Machine.Corpora
 
             int[] hypotheses = new int[] { 0, 1, 2 };
             int bestHypothesis = -1;
-            int bestNumCrossings = 200 ^ 2;
+            int bestNumCrossings = 40_000; // A large number
             var checkedHypotheses = new HashSet<int>();
             foreach (int hypothesis in hypotheses)
             {
@@ -380,7 +380,7 @@ namespace SIL.Machine.Corpora
                     {
                         // If aligning with a source token that precedes the marker,
                         // the target token predicted to be closest to the marker is the last aligned token rather than the first
-                        targetHypothesis = alignedTargetTokens[hypothesis < 0 ? -1 : 0];
+                        targetHypothesis = alignedTargetTokens[hypothesis < 0 ? alignedTargetTokens.Count - 1 : 0];
                     }
                     else
                     {


### PR DESCRIPTION
This PR fixes a minor bug noticed in PredictMarkerLocation() when investigating token alignment issues on the current build of Serval QA.

```cs
int bestNumCrossings = 40000;
```
The previous logic of `200 ^ 2` meant `200 XOR 2`, i.e. 202.

```cs
targetHypothesis = alignedTargetTokens[hypothesis < 0 ? alignedTargetTokens.Count - 1 : 0];
```
There is no -1 element in a list - I assume the last item was intended (see the Python implementation). That said this code isn't even called, as there is no hypothesis -1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine/495)
<!-- Reviewable:end -->
